### PR TITLE
Adding skip-reconcile feature

### DIFF
--- a/operator/redisfailover/handler.go
+++ b/operator/redisfailover/handler.go
@@ -59,6 +59,14 @@ func (r *RedisFailoverHandler) Handle(_ context.Context, obj runtime.Object) err
 		return fmt.Errorf("can't handle the received object: not a redisfailover")
 	}
 
+	if rf.Annotations != nil {
+		skipReconcile, ok := rf.Annotations["skip-reconcile"]
+		if ok && skipReconcile == "true" {
+			r.logger.Infoln("skip-reconcile set to true. Skipping reconcile for", rf.Name)
+			return nil
+		}
+	}
+
 	if err := rf.Validate(); err != nil {
 		r.mClient.SetClusterError(rf.Namespace, rf.Name)
 		return err


### PR DESCRIPTION
Fixes [ Issue #704](https://github.com/spotahome/redis-operator/issues/704#issue-2613525386).

## Changes proposed on the PR:
Add support for a skip-reconcile annotation that allows operators to temporarily pause reconciliation for specific Redis Failover resources. This gives operators more control during maintenance windows and migrations.

Example usage:
```
apiVersion: databases.spotahome.com/v1
kind: RedisFailover
metadata:
  name: redisfailover-sample
  annotations:
    skip-reconcile: "true"
spec:
  # ... rest of the spec
```
## Implementation Details
The implementation checks for the annotation at the start of the reconciliation loop:
```
if rf.Annotations != nil {
    skipReconcile, ok := rf.Annotations["skip-reconcile"]
    if ok && skipReconcile == "true" {
        r.logger.Infoln("skip-reconcile set to true. Skipping reconcile for", rf.Name)
        return nil
    }
}
```