### PR TITLE
Feature Request: Add masterPodAnnotations and slavePodAnnotations for role-specific Redis pod annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,13 @@ In order to use a custom Kubernetes [Service Account](https://kubernetes.io/docs
 By default, no pod annotations will be applied to Redis nor Sentinel pods.
 
 In order to apply custom pod Annotations, you can provide the `podAnnotations` option inside redis/sentinel spec. An example can be found in the [custom annotations example file](example/redisfailover/custom-annotations.yaml).
+
+#### Master and Slave Specific Pod Annotations
+For Redis pods, you can apply role-specific annotations using `masterPodAnnotations` and `slavePodAnnotations` in addition to common `podAnnotations`. This allows different annotations for master vs slave pods (e.g., backup configurations, monitoring, alerting).
+
+An example can be found in the [master-slave pod annotations example file](example/redisfailover/master-slave-pod-annotations.yaml).
+
+**Note**: These role-specific annotations are only available for Redis pods, not Sentinel pods.
 ### Custom Service Annotations
 By default, no service annotations will be applied to the Redis nor Sentinel services.
 

--- a/api/redisfailover/v1/types.go
+++ b/api/redisfailover/v1/types.go
@@ -59,6 +59,8 @@ type RedisSettings struct {
 	TopologySpreadConstraints     []corev1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
 	NodeSelector                  map[string]string                 `json:"nodeSelector,omitempty"`
 	PodAnnotations                map[string]string                 `json:"podAnnotations,omitempty"`
+	MasterPodAnnotations          map[string]string                 `json:"masterPodAnnotations,omitempty"`
+	SlavePodAnnotations           map[string]string                 `json:"slavePodAnnotations,omitempty"`
 	ServiceAnnotations            map[string]string                 `json:"serviceAnnotations,omitempty"`
 	HostNetwork                   bool                              `json:"hostNetwork,omitempty"`
 	DNSPolicy                     corev1.DNSPolicy                  `json:"dnsPolicy,omitempty"`

--- a/charts/redisoperator/Chart.yaml
+++ b/charts/redisoperator/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: 1.3.0
 apiVersion: v1
 description: A Helm chart for the Spotahome Redis Operator
 name: redis-operator
-version: 3.3.0
+version: 3.3.1
 home: https://github.com/freshworks/redis-operator
 keywords:
   - "golang"

--- a/example/redisfailover/master-slave-pod-annotations.yaml
+++ b/example/redisfailover/master-slave-pod-annotations.yaml
@@ -1,0 +1,26 @@
+apiVersion: databases.spotahome.com/v1
+kind: RedisFailover
+metadata:
+  name: redis-with-annotations
+spec:
+  sentinel:
+    replicas: 3
+  redis:
+    replicas: 3
+    # Common annotations applied to ALL Redis pods
+    podAnnotations:
+      monitoring/scrape: "true"
+      environment: "production"
+      team: "platform"
+    # Annotations applied ONLY to master pods (in addition to common annotations)
+    masterPodAnnotations:
+      role: "master"
+      priority: "high"
+      backup/enabled: "true"
+      alert/critical: "true"
+    # Annotations applied ONLY to slave pods (in addition to common annotations)
+    slavePodAnnotations:
+      role: "slave"
+      priority: "normal"
+      read-only: "true"
+      cache/enabled: "true"

--- a/manifests/databases.spotahome.com_redisfailovers.yaml
+++ b/manifests/databases.spotahome.com_redisfailovers.yaml
@@ -6828,6 +6828,14 @@ spec:
                     additionalProperties:
                       type: string
                     type: object
+                  masterPodAnnotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  slavePodAnnotations:
+                    additionalProperties:
+                      type: string
+                    type: object
                   port:
                     format: int32
                     type: integer

--- a/manifests/kustomize/base/databases.spotahome.com_redisfailovers.yaml
+++ b/manifests/kustomize/base/databases.spotahome.com_redisfailovers.yaml
@@ -6828,6 +6828,14 @@ spec:
                     additionalProperties:
                       type: string
                     type: object
+                  masterPodAnnotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  slavePodAnnotations:
+                    additionalProperties:
+                      type: string
+                    type: object
                   port:
                     format: int32
                     type: integer

--- a/mocks/service/k8s/Services.go
+++ b/mocks/service/k8s/Services.go
@@ -1071,6 +1071,24 @@ func (_m *Services) UpdatePodLabels(namespace string, podName string, labels map
 	return r0
 }
 
+// UpdatePodAnnotations provides a mock function with given fields: namespace, podName, annotations
+func (_m *Services) UpdatePodAnnotations(namespace string, podName string, annotations map[string]string) error {
+	ret := _m.Called(namespace, podName, annotations)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdatePodAnnotations")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, string, map[string]string) error); ok {
+		r0 = rf(namespace, podName, annotations)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // UpdateRole provides a mock function with given fields: namespace, role
 func (_m *Services) UpdateRole(namespace string, role *rbacv1.Role) error {
 	ret := _m.Called(namespace, role)

--- a/operator/redisfailover/service/check_test.go
+++ b/operator/redisfailover/service/check_test.go
@@ -178,6 +178,7 @@ func TestCheckAllSlavesFromMasterGetStatefulSetError(t *testing.T) {
 	ms := &mK8SService.Services{}
 	ms.On("GetStatefulSetPods", namespace, rfservice.GetRedisName(rf)).Once().Return(nil, errors.New(""))
 	ms.On("UpdatePodLabels", namespace, mock.AnythingOfType("string"), mock.Anything).Once().Return(nil)
+	ms.On("UpdatePodAnnotations", namespace, mock.AnythingOfType("string"), mock.Anything).Maybe().Return(nil)
 	mr := &mRedisService.Client{}
 
 	checker := rfservice.NewRedisFailoverChecker(ms, mr, log.DummyLogger{}, metrics.Dummy)
@@ -205,6 +206,7 @@ func TestCheckAllSlavesFromMasterGetSlaveOfError(t *testing.T) {
 	ms := &mK8SService.Services{}
 	ms.On("GetStatefulSetPods", namespace, rfservice.GetRedisName(rf)).Once().Return(pods, nil)
 	ms.On("UpdatePodLabels", namespace, mock.AnythingOfType("string"), mock.Anything).Once().Return(nil)
+	ms.On("UpdatePodAnnotations", namespace, mock.AnythingOfType("string"), mock.Anything).Maybe().Return(nil)
 	mr := &mRedisService.Client{}
 	mr.On("GetSlaveOf", "", "0", "").Once().Return("", errors.New(""))
 
@@ -233,6 +235,7 @@ func TestCheckAllSlavesFromMasterDifferentMaster(t *testing.T) {
 	ms := &mK8SService.Services{}
 	ms.On("GetStatefulSetPods", namespace, rfservice.GetRedisName(rf)).Once().Return(pods, nil)
 	ms.On("UpdatePodLabels", namespace, mock.AnythingOfType("string"), mock.Anything).Once().Return(nil)
+	ms.On("UpdatePodAnnotations", namespace, mock.AnythingOfType("string"), mock.Anything).Maybe().Return(nil)
 	mr := &mRedisService.Client{}
 	mr.On("GetSlaveOf", "0.0.0.0", "0", "").Once().Return("1.1.1.1", nil)
 
@@ -261,6 +264,7 @@ func TestCheckAllSlavesFromMaster(t *testing.T) {
 	ms := &mK8SService.Services{}
 	ms.On("GetStatefulSetPods", namespace, rfservice.GetRedisName(rf)).Once().Return(pods, nil)
 	ms.On("UpdatePodLabels", namespace, mock.AnythingOfType("string"), mock.Anything).Once().Return(nil)
+	ms.On("UpdatePodAnnotations", namespace, mock.AnythingOfType("string"), mock.Anything).Maybe().Return(nil)
 	mr := &mRedisService.Client{}
 	mr.On("GetSlaveOf", "0.0.0.0", "0", "").Once().Return("1.1.1.1", nil)
 

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -1161,3 +1161,37 @@ func getRedisEnv(rf *redisfailoverv1.RedisFailover) []corev1.EnvVar {
 
 	return env
 }
+
+// generateRedisMasterAnnotations combines common pod annotations with master-specific annotations
+func generateRedisMasterAnnotations(rf *redisfailoverv1.RedisFailover) map[string]string {
+	annotations := make(map[string]string)
+
+	// Add common pod annotations
+	for key, value := range rf.Spec.Redis.PodAnnotations {
+		annotations[key] = value
+	}
+
+	// Add master-specific annotations
+	for key, value := range rf.Spec.Redis.MasterPodAnnotations {
+		annotations[key] = value
+	}
+
+	return annotations
+}
+
+// generateRedisSlaveAnnotations combines common pod annotations with slave-specific annotations
+func generateRedisSlaveAnnotations(rf *redisfailoverv1.RedisFailover) map[string]string {
+	annotations := make(map[string]string)
+
+	// Add common pod annotations
+	for key, value := range rf.Spec.Redis.PodAnnotations {
+		annotations[key] = value
+	}
+
+	// Add slave-specific annotations
+	for key, value := range rf.Spec.Redis.SlavePodAnnotations {
+		annotations[key] = value
+	}
+
+	return annotations
+}

--- a/operator/redisfailover/service/heal_test.go
+++ b/operator/redisfailover/service/heal_test.go
@@ -35,6 +35,7 @@ func TestSetOldestAsMasterNewMasterError(t *testing.T) {
 	ms := &mK8SService.Services{}
 	ms.On("GetStatefulSetPods", namespace, rfservice.GetRedisName(rf)).Once().Return(pods, nil)
 	ms.On("UpdatePodLabels", namespace, mock.AnythingOfType("string"), mock.Anything).Return(nil)
+	ms.On("UpdatePodAnnotations", namespace, mock.AnythingOfType("string"), mock.Anything).Maybe().Return(nil)
 	mr := &mRedisService.Client{}
 	mr.On("MakeMaster", "0.0.0.0", "0", "").Once().Return(errors.New(""))
 
@@ -62,6 +63,7 @@ func TestSetOldestAsMaster(t *testing.T) {
 	ms := &mK8SService.Services{}
 	ms.On("GetStatefulSetPods", namespace, rfservice.GetRedisName(rf)).Once().Return(pods, nil)
 	ms.On("UpdatePodLabels", namespace, mock.AnythingOfType("string"), mock.Anything).Once().Return(nil)
+	ms.On("UpdatePodAnnotations", namespace, mock.AnythingOfType("string"), mock.Anything).Maybe().Return(nil)
 	mr := &mRedisService.Client{}
 	mr.On("MakeMaster", "0.0.0.0", "0", "").Once().Return(nil)
 
@@ -94,6 +96,7 @@ func TestSetOldestAsMasterMultiplePodsMakeSlaveOfError(t *testing.T) {
 	ms := &mK8SService.Services{}
 	ms.On("GetStatefulSetPods", namespace, rfservice.GetRedisName(rf)).Once().Return(pods, nil)
 	ms.On("UpdatePodLabels", namespace, mock.AnythingOfType("string"), mock.Anything).Return(nil)
+	ms.On("UpdatePodAnnotations", namespace, mock.AnythingOfType("string"), mock.Anything).Maybe().Return(nil)
 	mr := &mRedisService.Client{}
 	mr.On("MakeMaster", "0.0.0.0", "0", "").Once().Return(nil)
 	mr.On("MakeSlaveOfWithPort", "1.1.1.1", "0.0.0.0", "0", "").Once().Return(errors.New(""))
@@ -127,6 +130,7 @@ func TestSetOldestAsMasterMultiplePods(t *testing.T) {
 	ms := &mK8SService.Services{}
 	ms.On("GetStatefulSetPods", namespace, rfservice.GetRedisName(rf)).Once().Return(pods, nil)
 	ms.On("UpdatePodLabels", namespace, mock.AnythingOfType("string"), mock.Anything).Return(nil)
+	ms.On("UpdatePodAnnotations", namespace, mock.AnythingOfType("string"), mock.Anything).Maybe().Return(nil)
 	mr := &mRedisService.Client{}
 	mr.On("MakeMaster", "0.0.0.0", "0", "").Once().Return(nil)
 	mr.On("MakeSlaveOfWithPort", "1.1.1.1", "0.0.0.0", "0", "").Once().Return(nil)
@@ -170,6 +174,7 @@ func TestSetOldestAsMasterOrdering(t *testing.T) {
 	ms := &mK8SService.Services{}
 	ms.On("GetStatefulSetPods", namespace, rfservice.GetRedisName(rf)).Once().Return(pods, nil)
 	ms.On("UpdatePodLabels", namespace, mock.AnythingOfType("string"), mock.Anything).Return(nil)
+	ms.On("UpdatePodAnnotations", namespace, mock.AnythingOfType("string"), mock.Anything).Maybe().Return(nil)
 	mr := &mRedisService.Client{}
 	mr.On("MakeMaster", "1.1.1.1", "0", "").Once().Return(nil)
 	mr.On("MakeSlaveOfWithPort", "0.0.0.0", "1.1.1.1", "0", "").Once().Return(nil)
@@ -203,6 +208,7 @@ func TestSetMasterOnAllMakeMasterError(t *testing.T) {
 	ms := &mK8SService.Services{}
 	ms.On("GetStatefulSetPods", namespace, rfservice.GetRedisName(rf)).Once().Return(pods, nil)
 	ms.On("UpdatePodLabels", namespace, mock.AnythingOfType("string"), mock.Anything).Once().Return(nil)
+	ms.On("UpdatePodAnnotations", namespace, mock.AnythingOfType("string"), mock.Anything).Maybe().Return(nil)
 	mr := &mRedisService.Client{}
 	mr.On("IsMaster", "0.0.0.0", "0", "").Return(false, errors.New(""))
 	healer := rfservice.NewRedisFailoverHealer(ms, mr, log.DummyLogger{})
@@ -234,6 +240,7 @@ func TestSetMasterOnAllMakeSlaveOfError(t *testing.T) {
 	ms := &mK8SService.Services{}
 	ms.On("GetStatefulSetPods", namespace, rfservice.GetRedisName(rf)).Once().Return(pods, nil)
 	ms.On("UpdatePodLabels", namespace, mock.AnythingOfType("string"), mock.Anything).Return(nil)
+	ms.On("UpdatePodAnnotations", namespace, mock.AnythingOfType("string"), mock.Anything).Maybe().Return(nil)
 	mr := &mRedisService.Client{}
 	mr.On("IsMaster", "0.0.0.0", "0", "").Return(true, nil)
 	mr.On("MakeSlaveOfWithPort", "1.1.1.1", "0.0.0.0", "0", "").Once().Return(errors.New(""))
@@ -267,6 +274,7 @@ func TestSetMasterOnAll(t *testing.T) {
 	ms := &mK8SService.Services{}
 	ms.On("GetStatefulSetPods", namespace, rfservice.GetRedisName(rf)).Once().Return(pods, nil)
 	ms.On("UpdatePodLabels", namespace, mock.AnythingOfType("string"), mock.Anything).Return(nil)
+	ms.On("UpdatePodAnnotations", namespace, mock.AnythingOfType("string"), mock.Anything).Maybe().Return(nil)
 	mr := &mRedisService.Client{}
 	mr.On("IsMaster", "0.0.0.0", "0", "").Return(true, nil)
 	mr.On("MakeSlaveOfWithPort", "1.1.1.1", "0.0.0.0", "0", "").Once().Return(nil)

--- a/service/k8s/pod.go
+++ b/service/k8s/pod.go
@@ -2,9 +2,6 @@ package k8s
 
 import (
 	"context"
-	"encoding/json"
-
-	"k8s.io/apimachinery/pkg/types"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -24,6 +21,7 @@ type Pod interface {
 	DeletePod(namespace string, name string) error
 	ListPods(namespace string) (*corev1.PodList, error)
 	UpdatePodLabels(namespace, podName string, labels map[string]string) error
+	UpdatePodAnnotations(namespace, podName string, annotations map[string]string) error
 }
 
 // PodService is the pod service implementation using API calls to kubernetes.
@@ -110,21 +108,55 @@ type PatchStringValue struct {
 func (p *PodService) UpdatePodLabels(namespace, podName string, labels map[string]string) error {
 	p.logger.Infof("Update pod label, namespace: %s, pod name: %s, labels: %v", namespace, podName, labels)
 
-	var payloads []interface{}
-	for labelKey, labelValue := range labels {
-		payload := PatchStringValue{
-			Op:    "replace",
-			Path:  "/metadata/labels/" + labelKey,
-			Value: labelValue,
-		}
-		payloads = append(payloads, payload)
+	// Get the current pod
+	pod, err := p.GetPod(namespace, podName)
+	if err != nil {
+		p.logger.Errorf("Failed to get pod for label update, namespace: %s, pod name: %s, error: %v", namespace, podName, err)
+		return err
 	}
-	payloadBytes, _ := json.Marshal(payloads)
 
-	_, err := p.kubeClient.CoreV1().Pods(namespace).Patch(context.TODO(), podName, types.JSONPatchType, payloadBytes, metav1.PatchOptions{})
-	recordMetrics(namespace, "Pod", podName, "PATCH", err, p.metricsRecorder)
+	// Initialize labels map if it's nil
+	if pod.Labels == nil {
+		pod.Labels = make(map[string]string)
+	}
+
+	// Update the labels
+	for labelKey, labelValue := range labels {
+		pod.Labels[labelKey] = labelValue
+	}
+
+	// Update the pod
+	_, err = p.kubeClient.CoreV1().Pods(namespace).Update(context.TODO(), pod, metav1.UpdateOptions{})
+	recordMetrics(namespace, "Pod", podName, "UPDATE", err, p.metricsRecorder)
 	if err != nil {
 		p.logger.Errorf("Update pod labels failed, namespace: %s, pod name: %s, error: %v", namespace, podName, err)
+	}
+	return err
+}
+
+func (p *PodService) UpdatePodAnnotations(namespace, podName string, annotations map[string]string) error {
+	p.logger.Infof("Update pod annotations, namespace: %s, pod name: %s, annotations: %v", namespace, podName, annotations)
+
+	// Get the current pod
+	pod, err := p.GetPod(namespace, podName)
+	if err != nil {
+		p.logger.Errorf("Failed to get pod for annotation update, namespace: %s, pod name: %s, error: %v", namespace, podName, err)
+		return err
+	}
+
+	// Clear existing annotations and initialize if nil
+	pod.Annotations = make(map[string]string)
+
+	// Add the new annotations
+	for annotationKey, annotationValue := range annotations {
+		pod.Annotations[annotationKey] = annotationValue
+	}
+
+	// Update the pod
+	_, err = p.kubeClient.CoreV1().Pods(namespace).Update(context.TODO(), pod, metav1.UpdateOptions{})
+	recordMetrics(namespace, "Pod", podName, "UPDATE", err, p.metricsRecorder)
+	if err != nil {
+		p.logger.Errorf("Update pod annotations failed, namespace: %s, pod name: %s, error: %v", namespace, podName, err)
 	}
 	return err
 }


### PR DESCRIPTION
Fixes #35 

Changes proposed on the PR:
- Add `masterPodAnnotations` and `slavePodAnnotations` fields to RedisSettings API for role-specific pod annotations
- Implement dynamic annotation updates when Redis pods change roles during failovers
- Add `UpdatePodAnnotations` method to k8s service interface for pod annotation management
- Create annotation generation logic that combines common + role-specific annotations
- Update CRD schemas in both manifest files to include new annotation fields
- Add comprehensive unit tests with mocks for annotation functionality
- Add integration test to verify annotation application and removal during role changes
- Create example YAML demonstrating usage of master/slave specific annotations
- Update README.md with documentation for the new annotation features
- Optimize Makefile to use podman when available as alternative to docker