### PR TITLE
Update role label irrespective of connection failure from operator

### DIFF
--- a/operator/redisfailover/service/check.go
+++ b/operator/redisfailover/service/check.go
@@ -155,8 +155,12 @@ func (r *RedisFailoverChecker) CheckAllSlavesFromMaster(master string, rf *redis
 	}
 
 	rport := getRedisPort(rf.Spec.Redis.Port)
+	var connectivityErrors []error
+
+	// This ensures labels are always updated regardless of Redis connectivity issues
 	for _, rp := range rps.Items {
 		if rp.Status.PodIP == master {
+			r.logger.Infof("Update pod label, namespace: %s, pod name: %s, labels: %v", rf.Namespace, rp.Name, generateRedisMasterRoleLabel())
 			err = r.setMasterLabelIfNecessary(rf.Namespace, rp)
 			if err != nil {
 				return err
@@ -166,6 +170,7 @@ func (r *RedisFailoverChecker) CheckAllSlavesFromMaster(master string, rf *redis
 				return err
 			}
 		} else {
+			r.logger.Infof("Update pod label, namespace: %s, pod name: %s, labels: %v", rf.Namespace, rp.Name, generateRedisSlaveRoleLabel())
 			err = r.setSlaveLabelIfNecessary(rf.Namespace, rp)
 			if err != nil {
 				return err
@@ -175,16 +180,34 @@ func (r *RedisFailoverChecker) CheckAllSlavesFromMaster(master string, rf *redis
 				return err
 			}
 		}
+	}
 
+	// If any Redis instance is unresponsive, we log the error but don't fail the entire operation
+	for _, rp := range rps.Items {
 		slave, err := r.redisClient.GetSlaveOf(rp.Status.PodIP, rport, password)
 		if err != nil {
 			r.logger.Errorf("Get slave of master failed, maybe this node is not ready, pod ip: %s", rp.Status.PodIP)
-			return err
+			connectivityErrors = append(connectivityErrors, err)
+			continue // Continue checking other pods instead of failing immediately
 		}
 		if slave != "" && slave != master {
 			return fmt.Errorf("slave %s don't have the master %s, has %s", rp.Status.PodIP, master, slave)
 		}
 	}
+
+	// If ALL pods had connectivity errors, return an error
+	// This preserves the original behavior when all pods are unresponsive
+	if len(connectivityErrors) == len(rps.Items) && len(rps.Items) > 0 {
+		r.logger.Errorf("All Redis instances were unresponsive during replication check")
+		return connectivityErrors[0] // Return the first error
+	}
+
+	// If we had some connectivity errors but labels were updated successfully,
+	// log a warning but allow the healing process to continue
+	if len(connectivityErrors) > 0 {
+		r.logger.Warningf("Some Redis instances were unresponsive during replication check, but pod labels were updated successfully. Connectivity errors: %d", len(connectivityErrors))
+	}
+
 	return nil
 }
 
@@ -324,16 +347,23 @@ func (r *RedisFailoverChecker) GetMasterIP(rf *redisfailoverv1.RedisFailover) (s
 	}
 
 	masters := []string{}
+	connectivityErrors := 0
 	rport := getRedisPort(rf.Spec.Redis.Port)
 	for _, rip := range rips {
 		master, err := r.redisClient.IsMaster(rip, rport, password)
 		if err != nil {
 			r.logger.Errorf("Get redis info failed, maybe this node is not ready, pod ip: %s", rip)
+			connectivityErrors++
 			continue
 		}
 		if master {
 			masters = append(masters, rip)
 		}
+	}
+
+	// If all nodes are unresponsive, return an error
+	if connectivityErrors == len(rips) {
+		return "", errors.New("all redis nodes are unresponsive")
 	}
 
 	if len(masters) != 1 {
@@ -357,17 +387,25 @@ func (r *RedisFailoverChecker) GetNumberMasters(rf *redisfailoverv1.RedisFailove
 		return nMasters, err
 	}
 
+	connectivityErrors := 0
 	rport := getRedisPort(rf.Spec.Redis.Port)
 	for _, rip := range rips {
 		master, err := r.redisClient.IsMaster(rip, rport, password)
 		if err != nil {
 			r.logger.Errorf("Get redis info failed, maybe this node is not ready, pod ip: %s", rip)
+			connectivityErrors++
 			continue
 		}
 		if master {
 			nMasters++
 		}
 	}
+
+	// Log connectivity status for debugging
+	if connectivityErrors > 0 {
+		r.logger.Warningf("Found %d masters out of %d responsive nodes (%d nodes had connectivity issues)", nMasters, len(rips)-connectivityErrors, connectivityErrors)
+	}
+
 	return nMasters, nil
 }
 

--- a/service/redis/client.go
+++ b/service/redis/client.go
@@ -9,9 +9,9 @@ import (
 	"strconv"
 	"strings"
 
-	rediscli "github.com/go-redis/redis/v8"
 	"github.com/freshworks/redis-operator/log"
 	"github.com/freshworks/redis-operator/metrics"
+	rediscli "github.com/go-redis/redis/v8"
 )
 
 // Client defines the functions neccesary to connect to redis and sentinel to get or set what we nned
@@ -162,7 +162,6 @@ func (c *client) ResetSentinel(ip string) error {
 
 // GetSlaveOf returns the master of the given redis, or nil if it's master
 func (c *client) GetSlaveOf(ip, port, password string) (string, error) {
-
 	options := &rediscli.Options{
 		Addr:     net.JoinHostPort(ip, port),
 		Password: password,


### PR DESCRIPTION
Fix: Redis operator fails to update pod role labels during leader election

Fixes #34

## 🐛 **Problem**

When a Redis pod becomes unresponsive (e.g., due to `redis-cli debug sleep 300` or network issues), the Redis operator fails to update pod role labels after Sentinel completes a successful leader election. This results in:

- All pods showing wrong labels even after successful leader election
- Empty service endpoints (no master found)  

## 📋 **Steps to Reproduce**

1. Install RedisFailover resource with 3 replicas (quorum setup)
2. Manually hang current master: `redis-cli debug sleep 300`
3. <img width="847" height="219" alt="Screenshot 2025-09-19 at 10 02 18 PM" src="https://github.com/user-attachments/assets/57ed0e2f-14c0-4d73-bb1d-f1341e8286ef" />
4. <img width="1544" height="606" alt="Screenshot 2025-09-19 at 10 01 58 PM" src="https://github.com/user-attachments/assets/e71d805f-7783-472b-b5cf-3edbc3350522" />
5. Wait for Sentinel to complete leader election (new master promoted)
6. Check pod labels: `kubectl get pods -o yaml | yq .metadata.labels.redisfailovers-role`
7. <img width="1593" height="749" alt="Screenshot 2025-09-19 at 10 06 17 PM" src="https://github.com/user-attachments/assets/29625318-7dc3-418b-9c7a-3636b629d204" />
8. **Expected**: New master pod shows `master`, others show `slave`
9. **Actual**:  labels are not updated service endpoints empty


## 🔍 **Root Cause**

The `CheckAllSlavesFromMaster` function in `operator/redisfailover/service/check.go` had a critical flaw:

1. **Sequential processing**: Updates labels and checks Redis connectivity in the same loop
2. **Early exit on timeout**: When hitting an unresponsive pod, function returns error immediately  
3. **Incomplete processing**: Remaining pods never get their labels updated
4. **Stale state**: Service selectors can't find master pod due to incorrect labels

**Error logs showing the issue:**
```
time="2025-08-13T10:43:22Z" level=error msg="Get redis info failed, maybe this node is not ready, pod ip: 10.111.36.121"
time="2025-08-13T10:47:47Z" level=info msg="Update pod label, namespace: infra-dev, pod name: rfr-pigredis-1, labels: map[redisfailovers-role:master]"
```

## ✅ **Solution**

**Separated label updates from connectivity checks** into two distinct phases:

### **Phase 1: Always Update Labels** 
- Update ALL pod labels based on known master IP (from Sentinel)
- This phase always succeeds regardless of individual pod connectivity issues
- Ensures service endpoints work immediately

### **Phase 2: Check Connectivity (Non-blocking)**
- Verify Redis replication consistency 
- Log errors but don't block label updates
- Only fail if ALL pods are unresponsive (backward compatibility)

## 🔧 **Changes Made**

**Modified**: `operator/redisfailover/service/check.go`
- `CheckAllSlavesFromMaster()` function refactored
- Added two-phase processing approach

## 🧪 **Testing**

- ✅ All existing unit tests pass

## 📈 **Expected Behavior After Fix**

```
Before: Pod hangs → Timeout → Exit early → No labels updated → Service down
After:  Pod hangs → Labels updated first → Connectivity check fails → Continue → Service works
```

**Scenario walkthrough:**
1. Redis pod hangs (debug sleep 300)
2. <img width="1548" height="433" alt="Screenshot 2025-09-19 at 10 47 46 PM" src="https://github.com/user-attachments/assets/213d948d-33e5-4238-9f76-16d31ae95704" />
3. Sentinel elects new master
4. Operator detects new master via responsive pods
5. Updates ALL pod labels immediately
6. <img width="1501" height="768" alt="Screenshot 2025-09-19 at 10 48 13 PM" src="https://github.com/user-attachments/assets/3a7ee2f3-72bb-47ae-ae02-16e1e76b01fd" />
7. Service endpoints work → **No downtime!** 🎯