### PR TITLE
feat: add label-grouped RF operator

### DIFF
--- a/.cursor/rules/commits.mdc
+++ b/.cursor/rules/commits.mdc
@@ -1,9 +1,10 @@
 ---
-description: Do not add Co-authored-by for Cursor in git commits
+description: No Cursor attribution in git commits or generated content
 alwaysApply: true
 ---
 
 # Git commits
 
 - **Never** add a `Co-authored-by:` trailer (e.g. `Co-authored-by: Cursor <...>`) to commit messages.
-- Keep commit messages plain; no Co-authored-by lines.
+- **Never** add any attribution that mentions Cursor, e.g. `Made-with: Cursor`, `Made with Cursor`, or similar lines in commit messages or in generated content.
+- Keep commit messages and any generated text plain; no Co-authored-by, no Made-with, no other Cursor attribution.

--- a/.cursor/rules/commits.mdc
+++ b/.cursor/rules/commits.mdc
@@ -1,0 +1,9 @@
+---
+description: Do not add Co-authored-by for Cursor in git commits
+alwaysApply: true
+---
+
+# Git commits
+
+- **Never** add a `Co-authored-by:` trailer (e.g. `Co-authored-by: Cursor <...>`) to commit messages.
+- Keep commit messages plain; no Co-authored-by lines.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,35 @@ This redis-failover will be managed by the operator, resulting in the following 
 **NOTE**: `NAME` is the named provided when creating the RedisFailover.
 **IMPORTANT**: the name of the redis-failover to be created cannot be longer that 48 characters, due to prepend of redis/sentinel identification and statefulset limitation.
 
+### Label-sharded operator (operator groups)
+
+You can run multiple operator instances, each managing a subset of RedisFailover CRs, by using **operator groups**. Each instance has a group ID; it reconciles only CRs that carry the matching label. This gives flexible assignment (any namespace), server-side filtering via the API server, and no overlap between instances.
+
+1. **Set the group ID** for each operator instance (e.g. in the Deployment):
+
+   ```yaml
+   env:
+     - name: OPERATOR_GROUP_ID
+       value: "group-a"
+   ```
+
+   `OPERATOR_GROUP_ID` is required; the operator exits with an error if it is unset or empty.
+
+2. **Label RedisFailover CRs** with the group that should reconcile them:
+
+   ```yaml
+   apiVersion: databases.spotahome.com/v1
+   kind: RedisFailover
+   metadata:
+     name: my-redis
+     labels:
+       redis-failover.freshworks.com/operator-group: group-a
+   spec:
+     # ...
+   ```
+
+   Only CRs with `metadata.labels["redis-failover.freshworks.com/operator-group"] == <OPERATOR_GROUP_ID>` are reconciled by that operator. You can still use `--supported-namespaces-regex` to restrict which namespaces an instance watches; the group label then further limits which CRs in those namespaces are reconciled.
+
 ### Persistence
 
 The operator has the ability of add persistence to Redis data. By default an `emptyDir` will be used, so the data is not saved.

--- a/cmd/redisoperator/main.go
+++ b/cmd/redisoperator/main.go
@@ -98,6 +98,7 @@ func (m *Main) Run() error {
 
 	rfConfig := m.flags.ToRedisOperatorConfig()
 	rfConfig.OperatorGroupID = operatorGroupID
+	metricsRecorder.SetOperatorInfo(operatorGroupID, m.flags.SupportedNamespacesRegex)
 
 	// Create operator and run.
 	redisfailoverOperator, err := redisfailover.New(rfConfig, k8sservice, k8sClient, lockNamespace, redisClient, metricsRecorder, m.logger)

--- a/cmd/redisoperator/main.go
+++ b/cmd/redisoperator/main.go
@@ -87,8 +87,20 @@ func (m *Main) Run() error {
 	// Get lease lock resource namespace
 	lockNamespace := getNamespace()
 
+	// Shard ID is required for label-sharded operation.
+	operatorShardID := os.Getenv("OPERATOR_SHARD_ID")
+	if operatorShardID == "" {
+		log.Fatalf("OPERATOR_SHARD_ID environment variable is required and must be non-empty")
+	}
+	log.Infof("Starting RF Operator")
+	log.Infof("Shard ID: %s", operatorShardID)
+	log.Infof("Using label selector: redis-failover.freshworks.com/shard=%s", operatorShardID)
+
+	rfConfig := m.flags.ToRedisOperatorConfig()
+	rfConfig.OperatorShardID = operatorShardID
+
 	// Create operator and run.
-	redisfailoverOperator, err := redisfailover.New(m.flags.ToRedisOperatorConfig(), k8sservice, k8sClient, lockNamespace, redisClient, metricsRecorder, m.logger)
+	redisfailoverOperator, err := redisfailover.New(rfConfig, k8sservice, k8sClient, lockNamespace, redisClient, metricsRecorder, m.logger)
 	if err != nil {
 		return err
 	}

--- a/cmd/redisoperator/main.go
+++ b/cmd/redisoperator/main.go
@@ -90,11 +90,11 @@ func (m *Main) Run() error {
 	// Group ID is required for label-based grouping.
 	operatorGroupID := os.Getenv("OPERATOR_GROUP_ID")
 	if operatorGroupID == "" {
-		log.Fatalf("OPERATOR_GROUP_ID environment variable is required and must be non-empty")
+		log.Fatalf("operator_group_id environment variable is required and must be non-empty")
 	}
-	log.Infof("Starting RF Operator")
-	log.Infof("Operator group ID: %s", operatorGroupID)
-	log.Infof("Using label selector: redis-failover.freshworks.com/operator-group=%s", operatorGroupID)
+	log.Infof("starting rf operator")
+	log.Infof("operator group id: %s", operatorGroupID)
+	log.Infof("using label selector: redis-failover.freshworks.com/operator-group=%s", operatorGroupID)
 
 	rfConfig := m.flags.ToRedisOperatorConfig()
 	rfConfig.OperatorGroupID = operatorGroupID

--- a/cmd/redisoperator/main.go
+++ b/cmd/redisoperator/main.go
@@ -87,17 +87,17 @@ func (m *Main) Run() error {
 	// Get lease lock resource namespace
 	lockNamespace := getNamespace()
 
-	// Shard ID is required for label-sharded operation.
-	operatorShardID := os.Getenv("OPERATOR_SHARD_ID")
-	if operatorShardID == "" {
-		log.Fatalf("OPERATOR_SHARD_ID environment variable is required and must be non-empty")
+	// Group ID is required for label-based grouping.
+	operatorGroupID := os.Getenv("OPERATOR_GROUP_ID")
+	if operatorGroupID == "" {
+		log.Fatalf("OPERATOR_GROUP_ID environment variable is required and must be non-empty")
 	}
 	log.Infof("Starting RF Operator")
-	log.Infof("Shard ID: %s", operatorShardID)
-	log.Infof("Using label selector: redis-failover.freshworks.com/shard=%s", operatorShardID)
+	log.Infof("Operator group ID: %s", operatorGroupID)
+	log.Infof("Using label selector: redis-failover.freshworks.com/operator-group=%s", operatorGroupID)
 
 	rfConfig := m.flags.ToRedisOperatorConfig()
-	rfConfig.OperatorShardID = operatorShardID
+	rfConfig.OperatorGroupID = operatorGroupID
 
 	// Create operator and run.
 	redisfailoverOperator, err := redisfailover.New(rfConfig, k8sservice, k8sClient, lockNamespace, redisClient, metricsRecorder, m.logger)

--- a/metrics/dummy.go
+++ b/metrics/dummy.go
@@ -14,8 +14,9 @@ type dummy struct {
 	koopercontroller.MetricsRecorder
 }
 
-func (d *dummy) SetClusterOK(namespace string, name string)               {}
-func (d *dummy) SetClusterError(namespace string, name string)            {}
+func (d *dummy) SetOperatorInfo(operatorGroupID string, supportedNamespacesRegex string) {}
+func (d *dummy) SetClusterOK(namespace string, name string)                            {}
+func (d *dummy) SetClusterError(namespace string, name string)                          {}
 func (d *dummy) DeleteCluster(namespace string, name string)              {}
 func (d *dummy) SetRedisInstance(IP string, masterIP string, role string) {}
 func (d *dummy) ResetRedisInstance()                                      {}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -89,6 +89,10 @@ func NewMetricsTracker() *MetricsTracker {
 type Recorder interface {
 	koopercontroller.MetricsRecorder
 
+	// SetOperatorInfo sets the operator config/identity metric (operator_group_id, supported_namespaces_regex).
+	// Exposed as redis_operator_controller_operator_info with labels so Grafana can show them as strings.
+	SetOperatorInfo(operatorGroupID string, supportedNamespacesRegex string)
+
 	// ClusterOK metrics
 	SetClusterOK(namespace string, name string)
 	SetClusterError(namespace string, name string)
@@ -108,6 +112,7 @@ type Recorder interface {
 type recorder struct {
 	// Metrics fields.
 	metricsTracker       *MetricsTracker
+	operatorInfo         *prometheus.GaugeVec   // config/identity: which operator group this instance is reconciling (labels = strings for Grafana)
 	clusterOK            *prometheus.GaugeVec   // clusterOk is the status of a cluster
 	ensureResource       *prometheus.CounterVec // number of successful "ensure" operators performed by the controller.
 	redisCheck           *prometheus.CounterVec // indicates any error encountered in managed redis instance(s)
@@ -120,6 +125,14 @@ type recorder struct {
 // NewPrometheusMetrics returns a new PromMetrics object.
 func NewRecorder(namespace string, reg prometheus.Registerer) Recorder {
 	metricsTracker := NewMetricsTracker()
+
+	// Info-style config metric: value always 1; labels carry the string config for Grafana (operator_group_id, supported_namespaces_regex).
+	operatorInfo := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Subsystem: promControllerSubsystem,
+		Name:      "operator_info",
+		Help:      "Config/identity of this operator: which operator group it is reconciling. Value is 1; use labels operator_group_id and supported_namespaces_regex as strings in Grafana.",
+	}, []string{"operator_group_id", "supported_namespaces_regex"})
 
 	clusterOK := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: namespace,
@@ -168,6 +181,7 @@ func NewRecorder(namespace string, reg prometheus.Registerer) Recorder {
 	// Create the instance.
 	r := &recorder{
 		metricsTracker:       metricsTracker,
+		operatorInfo:         operatorInfo,
 		clusterOK:            clusterOK,
 		ensureResource:       ensureResource,
 		redisCheck:           redisCheck,
@@ -181,6 +195,7 @@ func NewRecorder(namespace string, reg prometheus.Registerer) Recorder {
 
 	// Register metrics.
 	reg.MustRegister(
+		r.operatorInfo,
 		r.clusterOK,
 		r.ensureResource,
 		r.redisCheck,
@@ -193,6 +208,10 @@ func NewRecorder(namespace string, reg prometheus.Registerer) Recorder {
 	go r.removeStaleMetrics()
 
 	return r
+}
+
+func (r *recorder) SetOperatorInfo(operatorGroupID string, supportedNamespacesRegex string) {
+	r.operatorInfo.WithLabelValues(operatorGroupID, supportedNamespacesRegex).Set(1)
 }
 
 func (r *recorder) SetClusterOK(namespace string, name string) {

--- a/operator/redisfailover/config.go
+++ b/operator/redisfailover/config.go
@@ -6,4 +6,7 @@ type Config struct {
 	MetricsPath              string
 	Concurrency              int
 	SupportedNamespacesRegex string
+	// OperatorShardID is the shard ID for label-based sharding. Only RF CRs with
+	// Only RF CRs with label redis-failover.freshworks.com/shard=<OperatorShardID> are reconciled by this instance.
+	OperatorShardID string
 }

--- a/operator/redisfailover/config.go
+++ b/operator/redisfailover/config.go
@@ -6,7 +6,8 @@ type Config struct {
 	MetricsPath              string
 	Concurrency              int
 	SupportedNamespacesRegex string
-	// OperatorShardID is the shard ID for label-based sharding. Only RF CRs with
-	// Only RF CRs with label redis-failover.freshworks.com/shard=<OperatorShardID> are reconciled by this instance.
-	OperatorShardID string
+	// OperatorGroupID is the group ID for label-based grouping.
+	// Only RF CRs with label redis-failover.freshworks.com/operator-group=<OperatorGroupID>
+	// are reconciled by this instance.
+	OperatorGroupID string
 }

--- a/operator/redisfailover/factory.go
+++ b/operator/redisfailover/factory.go
@@ -27,7 +27,7 @@ const (
 	resync             = 30 * time.Second
 	operatorName       = "redis-operator"
 	lockKey            = "redis-failover-lease"
-	rfOperatorShardKey = "redis-failover.freshworks.com/shard"
+	rfOperatorGroupKey = "redis-failover.freshworks.com/operator-group"
 )
 
 // New will create an operator that is responsible of managing all the required stuff
@@ -68,14 +68,14 @@ func NewRedisFailoverRetriever(cfg Config, cli k8s.Services) controller.Retrieve
 		return match
 	}
 
-	// Server-side label selector so only RF CRs for this shard are listed/watched.
-	shardSelector := labels.SelectorFromSet(map[string]string{
-		rfOperatorShardKey: cfg.OperatorShardID,
+	// Server-side label selector so only RF CRs for this group are listed/watched.
+	groupSelector := labels.SelectorFromSet(map[string]string{
+		rfOperatorGroupKey: cfg.OperatorGroupID,
 	}).String()
 
 	return controller.MustRetrieverFromListerWatcher(&cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-			options.LabelSelector = shardSelector
+			options.LabelSelector = groupSelector
 			rfList, err := cli.ListRedisFailovers(context.Background(), "", options)
 			if err != nil {
 				return rfList, err
@@ -92,7 +92,7 @@ func NewRedisFailoverRetriever(cfg Config, cli k8s.Services) controller.Retrieve
 			return rfList, err
 		},
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-			options.LabelSelector = shardSelector
+			options.LabelSelector = groupSelector
 			watcher, err := cli.WatchRedisFailovers(context.Background(), "", options)
 			watcher = watch.Filter(watcher, func(event watch.Event) (watch.Event, bool) {
 				rf, ok := event.Object.(*redisfailoverv1.RedisFailover)

--- a/operator/redisfailover/factory.go
+++ b/operator/redisfailover/factory.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spotahome/kooper/v2/controller/leaderelection"
 	kooperlog "github.com/spotahome/kooper/v2/log"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
@@ -23,9 +24,10 @@ import (
 )
 
 const (
-	resync       = 30 * time.Second
-	operatorName = "redis-operator"
-	lockKey      = "redis-failover-lease"
+	resync             = 30 * time.Second
+	operatorName       = "redis-operator"
+	lockKey            = "redis-failover-lease"
+	rfOperatorShardKey = "redis-failover.freshworks.com/shard"
 )
 
 // New will create an operator that is responsible of managing all the required stuff
@@ -65,10 +67,15 @@ func NewRedisFailoverRetriever(cfg Config, cli k8s.Services) controller.Retrieve
 		match, _ := regexp.Match(cfg.SupportedNamespacesRegex, []byte(rf.Namespace))
 		return match
 	}
-	// check in the startup whether the regex compiles
+
+	// Server-side label selector so only RF CRs for this shard are listed/watched.
+	shardSelector := labels.SelectorFromSet(map[string]string{
+		rfOperatorShardKey: cfg.OperatorShardID,
+	}).String()
 
 	return controller.MustRetrieverFromListerWatcher(&cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			options.LabelSelector = shardSelector
 			rfList, err := cli.ListRedisFailovers(context.Background(), "", options)
 			if err != nil {
 				return rfList, err
@@ -85,6 +92,7 @@ func NewRedisFailoverRetriever(cfg Config, cli k8s.Services) controller.Retrieve
 			return rfList, err
 		},
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			options.LabelSelector = shardSelector
 			watcher, err := cli.WatchRedisFailovers(context.Background(), "", options)
 			watcher = watch.Filter(watcher, func(event watch.Event) (watch.Event, bool) {
 				rf, ok := event.Object.(*redisfailoverv1.RedisFailover)

--- a/operator/redisfailover/factory.go
+++ b/operator/redisfailover/factory.go
@@ -26,7 +26,7 @@ import (
 const (
 	resync             = 30 * time.Second
 	operatorName       = "redis-operator"
-	lockKey            = "redis-failover-lease"
+	lockKeyPrefix      = "redis-failover-lease"
 	rfOperatorGroupKey = "redis-failover.freshworks.com/operator-group"
 )
 
@@ -43,7 +43,8 @@ func New(cfg Config, k8sService k8s.Services, k8sClient kubernetes.Interface, lo
 	rfRetriever := NewRedisFailoverRetriever(cfg, k8sService)
 
 	kooperLogger := kooperlogger{Logger: logger.WithField("operator", "redisfailover")}
-	// Leader election service.
+	// Leader election service: one lease per operator group so each deployment can be leader for its group.
+	lockKey := lockKeyPrefix + "-" + cfg.OperatorGroupID
 	leSVC, err := leaderelection.NewDefault(lockKey, lockNamespace, k8sClient, kooperLogger)
 	if err != nil {
 		return nil, err

--- a/test/integration/redisfailover/creation_test.go
+++ b/test/integration/redisfailover/creation_test.go
@@ -38,13 +38,15 @@ import (
 )
 
 const (
-	name           = "testing"
-	namespace      = "testns"
-	redisSize      = int32(3)
-	sentinelSize   = int32(3)
-	authSecretPath = "redis-auth"
-	testPass       = "test-pass"
-	redisAddr      = "redis://127.0.0.1:6379"
+	name                    = "testing"
+	namespace               = "testns"
+	redisSize               = int32(3)
+	sentinelSize            = int32(3)
+	authSecretPath          = "redis-auth"
+	testPass                = "test-pass"
+	redisAddr               = "redis://127.0.0.1:6379"
+	integrationTestShardID   = "integration-test"
+	rfOperatorShardLabelKey = "redis-failover.freshworks.com/shard"
 )
 
 type clients struct {
@@ -112,8 +114,8 @@ func TestRedisFailover(t *testing.T) {
 	// Give time to the namespace to be ready
 	time.Sleep(15 * time.Second)
 
-	// Create operator and run.
-	redisfailoverOperator, err := redisfailover.New(redisfailover.Config{}, k8sservice, k8sClient, currentNamespace, redisClient, metrics.Dummy, log.Dummy)
+	// Create operator and run (label-sharded; tests use integrationTestShardID).
+	redisfailoverOperator, err := redisfailover.New(redisfailover.Config{OperatorShardID: integrationTestShardID}, k8sservice, k8sClient, currentNamespace, redisClient, metrics.Dummy, log.Dummy)
 	require.NoError(err)
 
 	go func() {
@@ -245,8 +247,8 @@ func TestRedisFailoverMyMaster(t *testing.T) {
 	// Give time to the namespace to be ready
 	time.Sleep(15 * time.Second)
 
-	// Create operator and run.
-	redisfailoverOperator, err := redisfailover.New(redisfailover.Config{}, k8sservice, k8sClient, currentNamespace, redisClient, metrics.Dummy, log.Dummy)
+	// Create operator and run (label-sharded; tests use integrationTestShardID).
+	redisfailoverOperator, err := redisfailover.New(redisfailover.Config{OperatorShardID: integrationTestShardID}, k8sservice, k8sClient, currentNamespace, redisClient, metrics.Dummy, log.Dummy)
 	require.NoError(err)
 
 	go func() {
@@ -328,6 +330,7 @@ func (c *clients) testCRCreation(t *testing.T, currentNamespace string, args ...
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: currentNamespace,
+			Labels:    map[string]string{rfOperatorShardLabelKey: integrationTestShardID},
 		},
 		Spec: redisfailoverv1.RedisFailoverSpec{
 			Redis: redisfailoverv1.RedisSettings{
@@ -623,6 +626,7 @@ func (c *clients) testMaxMemoryValidationError(t *testing.T, currentNamespace st
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      rfName,
 			Namespace: currentNamespace,
+			Labels:    map[string]string{rfOperatorShardLabelKey: integrationTestShardID},
 		},
 		Spec: redisfailoverv1.RedisFailoverSpec{
 			Redis: redisfailoverv1.RedisSettings{
@@ -673,6 +677,7 @@ func (c *clients) testMaxMemoryHealingValidation(t *testing.T, currentNamespace 
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      rfName,
 			Namespace: currentNamespace,
+			Labels:    map[string]string{rfOperatorShardLabelKey: integrationTestShardID},
 		},
 		Spec: redisfailoverv1.RedisFailoverSpec{
 			Redis: redisfailoverv1.RedisSettings{

--- a/test/integration/redisfailover/creation_test.go
+++ b/test/integration/redisfailover/creation_test.go
@@ -45,8 +45,8 @@ const (
 	authSecretPath          = "redis-auth"
 	testPass                = "test-pass"
 	redisAddr               = "redis://127.0.0.1:6379"
-	integrationTestShardID   = "integration-test"
-	rfOperatorShardLabelKey = "redis-failover.freshworks.com/shard"
+	integrationTestGroupID   = "integration-test"
+	rfOperatorGroupLabelKey = "redis-failover.freshworks.com/operator-group"
 )
 
 type clients struct {
@@ -114,8 +114,8 @@ func TestRedisFailover(t *testing.T) {
 	// Give time to the namespace to be ready
 	time.Sleep(15 * time.Second)
 
-	// Create operator and run (label-sharded; tests use integrationTestShardID).
-	redisfailoverOperator, err := redisfailover.New(redisfailover.Config{OperatorShardID: integrationTestShardID}, k8sservice, k8sClient, currentNamespace, redisClient, metrics.Dummy, log.Dummy)
+	// Create operator and run (label-grouped; tests use integrationTestGroupID).
+	redisfailoverOperator, err := redisfailover.New(redisfailover.Config{OperatorGroupID: integrationTestGroupID}, k8sservice, k8sClient, currentNamespace, redisClient, metrics.Dummy, log.Dummy)
 	require.NoError(err)
 
 	go func() {
@@ -247,8 +247,8 @@ func TestRedisFailoverMyMaster(t *testing.T) {
 	// Give time to the namespace to be ready
 	time.Sleep(15 * time.Second)
 
-	// Create operator and run (label-sharded; tests use integrationTestShardID).
-	redisfailoverOperator, err := redisfailover.New(redisfailover.Config{OperatorShardID: integrationTestShardID}, k8sservice, k8sClient, currentNamespace, redisClient, metrics.Dummy, log.Dummy)
+	// Create operator and run (label-grouped; tests use integrationTestGroupID).
+	redisfailoverOperator, err := redisfailover.New(redisfailover.Config{OperatorGroupID: integrationTestGroupID}, k8sservice, k8sClient, currentNamespace, redisClient, metrics.Dummy, log.Dummy)
 	require.NoError(err)
 
 	go func() {
@@ -330,7 +330,7 @@ func (c *clients) testCRCreation(t *testing.T, currentNamespace string, args ...
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: currentNamespace,
-			Labels:    map[string]string{rfOperatorShardLabelKey: integrationTestShardID},
+			Labels:    map[string]string{rfOperatorGroupLabelKey: integrationTestGroupID},
 		},
 		Spec: redisfailoverv1.RedisFailoverSpec{
 			Redis: redisfailoverv1.RedisSettings{
@@ -626,7 +626,7 @@ func (c *clients) testMaxMemoryValidationError(t *testing.T, currentNamespace st
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      rfName,
 			Namespace: currentNamespace,
-			Labels:    map[string]string{rfOperatorShardLabelKey: integrationTestShardID},
+			Labels:    map[string]string{rfOperatorGroupLabelKey: integrationTestGroupID},
 		},
 		Spec: redisfailoverv1.RedisFailoverSpec{
 			Redis: redisfailoverv1.RedisSettings{
@@ -677,7 +677,7 @@ func (c *clients) testMaxMemoryHealingValidation(t *testing.T, currentNamespace 
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      rfName,
 			Namespace: currentNamespace,
-			Labels:    map[string]string{rfOperatorShardLabelKey: integrationTestShardID},
+			Labels:    map[string]string{rfOperatorGroupLabelKey: integrationTestGroupID},
 		},
 		Spec: redisfailoverv1.RedisFailoverSpec{
 			Redis: redisfailoverv1.RedisSettings{


### PR DESCRIPTION
# Label-grouped RF operator (alternative to explicit namespace list)

Closes #41 

## Summary

Issue #41 requested support for an **explicit list of namespaces** to reconcile (e.g. `--supported-namespaces=ns1,ns2,ns3`) in addition to the existing regex. We implemented a different approach that achieves the same goal and scales better: **label-based grouping**.

Instead of a namespace list, each operator instance is assigned a **group ID**. It reconciles only RedisFailover CRs that have the matching label. This gives:

- **Flexible assignment**: You decide which CRs (in any namespaces) belong to which operator by setting a label on the CR.
- **Server-side filtering**: List and Watch use a label selector so the API server only returns CRs for that group (no client-side filtering of a full list).
- **Multiple operator instances**: Run several operators (e.g. one per group) with no overlap; each sees only its CRs.

## Implementation

### Behaviour

- **OPERATOR_GROUP_ID** (env, required): Identifies this operator instance. If unset or empty, the operator logs a fatal error and exits.
- **Label**: Only CRs with `metadata.labels["redis-failover.freshworks.com/operator-group"] == OPERATOR_GROUP_ID` are reconciled.
- **List/Watch**: Use server-side label selector `redis-failover.freshworks.com/operator-group=<OPERATOR_GROUP_ID>` so the API does the filtering.
- **Startup**: Operator logs group ID and the label selector in use.

### Changes

- **Config**: `OperatorGroupID` added to operator config (set from env in `main`).
- **Factory**: Retriever’s List and Watch pass the group label selector in `ListOptions`/watch options.
- **Main**: Read `OPERATOR_GROUP_ID` at startup; fatal if empty; log group ID and selector; pass group ID into config.
- **Integration tests**: Use a fixed group ID and add the operator-group label to all created RedisFailover CRs.

### Usage

1. Set the env var for each operator instance, e.g. in the Deployment:
   ```yaml
   env:
     - name: OPERATOR_GROUP_ID
       value: "group-a"
   ```

2. Label RedisFailover CRs with the group that should reconcile them:
   ```yaml
   metadata:
     labels:
       redis-failover.freshworks.com/operator-group: group-a
   ```

3. Operator A with `OPERATOR_GROUP_ID=group-a` reconciles only CRs with that label (in any namespace that still matches `--supported-namespaces-regex`). Operator B with `OPERATOR_GROUP_ID=group-b` never sees those CRs.

### Relation to #41 

#41 asked for an explicit namespace list. This solution does not add `--supported-namespaces`. It uses **group labels** so you can:

- Limit which CRs an instance reconciles (by assigning them to groups).
- Effectively “scope” an operator to a set of CRs that can span any namespaces, without maintaining a namespace list and with server-side filtering.

If you need “only these namespaces,” you can run one group and label only the CRs in those namespaces with that group ID; the existing `--supported-namespaces-regex` can still be used in addition to narrow by namespace when desired.

## Checklist

- [x] OPERATOR_GROUP_ID required at startup (fatal if empty)
- [x] Server-side label selector on List and Watch
- [x] Startup logs group ID and selector
- [x] Integration tests updated (operator-group label on test CRs)
