### PR TITLE
feat: add disableMasterRollout option to rollout only Redis slaves

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,22 @@ Add the `redis-failover.freshworks.com/skip-reconcile: "true"` annotation to you
 
 The operator will still log that it's skipping reconciliation for the resource, so you can verify the feature is working as expected.
 
+### Disable Master Rollout
+
+The Redis StatefulSet uses an **OnDelete** update strategy: pods are only restarted when the operator deletes them so they get the new spec. By default, the operator deletes both slave and master pods when their revision is stale.
+
+When `disableMasterRollout` is set to `true` under `spec.redis`, the operator will **only** delete slave pods for rollout. The current master pod is never deleted for rollout until the flag is removed. All other reconciliation (labels, healing, sentinel config, etc.) runs as usual.
+
+This is useful for **planned failovers** or upgrades where you want to rollout slaves first and control when the master is restarted (e.g. after slaves have synced).
+
+#### Usage
+
+Set `spec.redis.disableMasterRollout: true` in your RedisFailover. When you change the Redis spec (e.g. image), only slave pods will be deleted and recreated. When you are ready to rollout the master, set `disableMasterRollout: false` (or remove it); on the next reconcile the operator will delete the master pod and it will be recreated with the new spec (a brief failover will occur).
+
+See the [disable master rollout example](example/redisfailover/disable-master-rollout.yaml).
+
+**Note**: While the flag is set, the master runs the old spec (image/config); remove the flag when you want the master to get the new spec.
+
 ### Custom shutdown script
 
 By default, a custom shutdown file is given. This file makes redis to `SAVE` it's data, and in the case that redis is master, it'll call sentinel to ask for a failover.

--- a/api/redisfailover/v1/types.go
+++ b/api/redisfailover/v1/types.go
@@ -73,6 +73,7 @@ type RedisSettings struct {
 	CustomStartupProbe            *corev1.Probe                     `json:"customStartupProbe,omitempty"`
 	DisablePodDisruptionBudget    bool                              `json:"disablePodDisruptionBudget,omitempty"`
 	PreventMasterEviction         bool                              `json:"preventMasterEviction,omitempty"`
+	DisableMasterRollout          bool                              `json:"disableMasterRollout,omitempty"`
 }
 
 // SentinelSettings defines the specification of the sentinel cluster

--- a/charts/redisoperator/Chart.yaml
+++ b/charts/redisoperator/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: 1.3.0
 apiVersion: v1
 description: A Helm chart for the Spotahome Redis Operator
 name: redis-operator
-version: 3.3.2
+version: 3.3.3
 home: https://github.com/freshworks/redis-operator
 keywords:
   - "golang"

--- a/charts/redisoperator/crds/databases.spotahome.com_redisfailovers.yaml
+++ b/charts/redisoperator/crds/databases.spotahome.com_redisfailovers.yaml
@@ -5574,6 +5574,9 @@ spec:
                     type: integer
                   priorityClassName:
                     type: string
+                  disableMasterRollout:
+                    description: When true, only slave pods are rolled out on spec change (OnDelete); master is not deleted until this is false.
+                    type: boolean
                   replicas:
                     format: int32
                     type: integer

--- a/charts/redisoperator/crds/databases.spotahome.com_redisfailovers.yaml
+++ b/charts/redisoperator/crds/databases.spotahome.com_redisfailovers.yaml
@@ -5575,6 +5575,7 @@ spec:
                   priorityClassName:
                     type: string
                   disableMasterRollout:
+                    default: false
                     description: When true, only slave pods are rolled out on spec change (OnDelete); master is not deleted until this is false.
                     type: boolean
                   replicas:

--- a/example/redisfailover/disable-master-rollout.yaml
+++ b/example/redisfailover/disable-master-rollout.yaml
@@ -1,0 +1,24 @@
+apiVersion: databases.spotahome.com/v1
+kind: RedisFailover
+metadata:
+  name: redisfailover
+  namespace: default
+spec:
+  sentinel:
+    replicas: 3
+    resources:
+      requests:
+        cpu: 100m
+      limits:
+        memory: 100Mi
+  redis:
+    replicas: 3
+    # Only rollout slave pods on spec change (OnDelete); master is not deleted until this is false.
+    disableMasterRollout: true
+    resources:
+      requests:
+        cpu: 100m
+        memory: 100Mi
+      limits:
+        cpu: 400m
+        memory: 500Mi

--- a/manifests/databases.spotahome.com_redisfailovers.yaml
+++ b/manifests/databases.spotahome.com_redisfailovers.yaml
@@ -6836,6 +6836,9 @@ spec:
                     type: integer
                   preventMasterEviction:
                     type: boolean
+                  disableMasterRollout:
+                    description: When true, only slave pods are rolled out on spec change (OnDelete); master is not deleted until this is false.
+                    type: boolean
                   priorityClassName:
                     type: string
                   replicas:

--- a/manifests/databases.spotahome.com_redisfailovers.yaml
+++ b/manifests/databases.spotahome.com_redisfailovers.yaml
@@ -6837,6 +6837,7 @@ spec:
                   preventMasterEviction:
                     type: boolean
                   disableMasterRollout:
+                    default: false
                     description: When true, only slave pods are rolled out on spec change (OnDelete); master is not deleted until this is false.
                     type: boolean
                   priorityClassName:

--- a/manifests/kustomize/base/databases.spotahome.com_redisfailovers.yaml
+++ b/manifests/kustomize/base/databases.spotahome.com_redisfailovers.yaml
@@ -6834,6 +6834,7 @@ spec:
                   preventMasterEviction:
                     type: boolean
                   disableMasterRollout:
+                    default: false
                     description: When true, only slave pods are rolled out on spec change (OnDelete); master is not deleted until this is false.
                     type: boolean
                   priorityClassName:

--- a/manifests/kustomize/base/databases.spotahome.com_redisfailovers.yaml
+++ b/manifests/kustomize/base/databases.spotahome.com_redisfailovers.yaml
@@ -6833,6 +6833,9 @@ spec:
                     type: integer
                   preventMasterEviction:
                     type: boolean
+                  disableMasterRollout:
+                    description: When true, only slave pods are rolled out on spec change (OnDelete); master is not deleted until this is false.
+                    type: boolean
                   priorityClassName:
                     type: string
                   replicas:

--- a/operator/redisfailover/checker.go
+++ b/operator/redisfailover/checker.go
@@ -9,7 +9,8 @@ import (
 	"github.com/freshworks/redis-operator/metrics"
 )
 
-// UpdateRedisesPods if the running version of pods are equal to the statefulset one
+// UpdateRedisesPods deletes Redis pods with a stale StatefulSet revision (OnDelete rollout).
+// DisableMasterRollout when true, only slave pods are rolled out on spec change (OnDelete); master is not deleted until the flag is removed.
 func (r *RedisFailoverHandler) UpdateRedisesPods(rf *redisfailoverv1.RedisFailover) error {
 	redises, err := r.rfChecker.GetRedisesIPs(rf)
 	if err != nil {
@@ -59,8 +60,7 @@ func (r *RedisFailoverHandler) UpdateRedisesPods(rf *redisfailoverv1.RedisFailov
 		}
 	}
 
-	if !rf.Bootstrapping() {
-		// Update stale pod with role master
+	if !rf.Bootstrapping() && !rf.Spec.Redis.DisableMasterRollout {
 		master, err := r.rfChecker.GetRedisesMasterPod(rf)
 		if err != nil {
 			return err


### PR DESCRIPTION
Fixes #43

Adds `spec.redis.disableMasterRollout`: when enabled, the operator only deletes slave pods for StatefulSet revision rollout (OnDelete); the master pod is not deleted until the option is cleared. Enables coordinated multi-endpoint upgrades and safer rollout when a revision is bad.

Changes proposed on the PR:
- Add `DisableMasterRollout` field to `RedisSettings` in API types
- Skip master pod deletion in `UpdateRedisesPods` when `disableMasterRollout` is true
- Document the option in README (Disable Master Rollout section)
- Add example manifest `example/redisfailover/disable-master-rollout.yaml`