### PR TITLE
docs & CI: unify Freshworks + GHCR OCI, Helm chart workflow, release docs

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -1,50 +1,40 @@
 name: Release Charts
 
+# Publish the Helm chart to GHCR as OCI only (no chart-releaser, no gh-pages).
 on:
   push:
     branches:
       - master
+    # Only chart content changes should publish; workflow-only commits avoid duplicate helm push of the same version.
+    paths:
+      - "charts/**"
+
+permissions:
+  contents: read
+  packages: write
 
 jobs:
-  release:
+  oci-chart:
+    name: Package and push chart to GHCR
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v4 
+        uses: azure/setup-helm@v4
         with:
           version: v3.12.3
 
-      - name: Release
-        uses: helm/chart-releaser-action@v1.5.0
-        id: cr
-        with:
-          charts_dir: charts
-          config: charts/chart-release-config.yaml
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-
-      # setup access to container registry
-      - name: Setup access to container registry
-        uses: docker/login-action@v3
-        if: ${{ steps.cr.outputs.changed_charts }}
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      # push charts to container registry
-      - name: Push charts to container registry
-        if: ${{ steps.cr.outputs.changed_charts }}
+      # helm push uses Helm's OCI client; configure auth via helm registry login (not only docker).
+      - name: Helm registry login to GHCR
         run: |
-          for CHART in .cr-release-packages/*; do
-            if [ -z "${CHART:-}" ]; then break; fi
-            helm push "${CHART}" oci://ghcr.io/${{ github.repository_owner }}/charts
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u "${{ github.repository_owner }}" --password-stdin
+
+      - name: Package and push Helm chart to GHCR
+        run: |
+          set -euo pipefail
+          out="$(mktemp -d)"
+          helm package charts/redisoperator --destination "${out}"
+          for tgz in "${out}"/*.tgz; do
+            helm push "${tgz}" "oci://ghcr.io/${{ github.repository_owner }}/charts"
           done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Update notes:
 
 Ensure you update the CRD definition since CRD is no longer managed by the operator:
 ```
-kubectl create -f https://raw.githubusercontent.com/spotahome/redis-operator/master/example/redisfailover/basic.yaml
+kubectl create -f https://raw.githubusercontent.com/freshworks/redis-operator/master/example/redisfailover/basic.yaml
 ```
 
 ## [v1.1.0-rc.1] - 2022-01-12

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 Redis Operator creates/configures/manages redis-failovers atop Kubernetes.
 
+**API group vs project:** The `RedisFailover` CRD is served under the API group `databases.spotahome.com` (unchanged for compatibility). This fork is developed under **Freshworks**; clone URLs, `raw.githubusercontent.com` links, and container images use **`freshworks`** (e.g. `ghcr.io/freshworks/redis-operator`). Renaming the API group would be a breaking change for existing clusters and is not part of this project’s scope.
+
 ## Requirements
 
 Kubernetes version: 1.21 or higher
@@ -20,13 +22,32 @@ It can be done with plain old [deployment](example/operator), using [Kustomize](
 
 ### Using the Helm chart
 
-From the root folder of the project, execute the following:
+Charts are published to **GitHub Container Registry (GHCR)** as OCI artifacts only (no `helm repo add` / GitHub Pages index). After CI runs, the chart appears under the org’s **GitHub Packages** and is pulled as:
+
+`oci://ghcr.io/freshworks/charts/redis-operator`
+
+Authenticate to GHCR with `helm registry login ghcr.io` if your org uses private packages.
+
+| What | Where |
+|------|--------|
+| Helm `helm install --version` | [Chart.yaml](charts/redisoperator/Chart.yaml) `version` (e.g. `3.3.3`) |
+| Suggested app semver | Chart `appVersion` |
+| Operator image | [values](charts/redisoperator/values.yaml) `image.repository` + `image.tag` (default matches published `ghcr.io/freshworks/redis-operator`) |
+
+Install (set the chart version to match the package you want):
 
 ```
-helm repo add redis-operator https://spotahome.github.io/redis-operator
-helm repo update
-helm install redis-operator redis-operator/redis-operator
+REDIS_OPERATOR_CHART_VERSION=3.3.3
+helm install redis-operator oci://ghcr.io/freshworks/charts/redis-operator --version "${REDIS_OPERATOR_CHART_VERSION}"
 ```
+
+Upgrade:
+
+```
+helm upgrade redis-operator oci://ghcr.io/freshworks/charts/redis-operator --version "${REDIS_OPERATOR_CHART_VERSION}"
+```
+
+If the repository still has a legacy **`gh-pages`** branch from the old Helm index workflow, you can delete it; chart distribution is **GHCR OCI** only.
 
 #### Update helm chart
 
@@ -38,7 +59,8 @@ kubectl replace -f https://raw.githubusercontent.com/freshworks/redis-operator/$
 ```
 
 ```
-helm upgrade redis-operator redis-operator/redis-operator
+REDIS_OPERATOR_CHART_VERSION=3.3.3
+helm upgrade redis-operator oci://ghcr.io/freshworks/charts/redis-operator --version "${REDIS_OPERATOR_CHART_VERSION}"
 ```
 ### Using kubectl
 
@@ -99,7 +121,7 @@ In order to deploy a new redis-failover a [specification](example/redisfailover/
 
 ```
 REDIS_OPERATOR_VERSION=v1.2.4
-kubectl create -f https://raw.githubusercontent.com/spotahome/redis-operator/${REDIS_OPERATOR_VERSION}/example/redisfailover/basic.yaml
+kubectl create -f https://raw.githubusercontent.com/freshworks/redis-operator/${REDIS_OPERATOR_VERSION}/example/redisfailover/basic.yaml
 ```
 
 This redis-failover will be managed by the operator, resulting in the following elements created inside Kubernetes:
@@ -480,6 +502,8 @@ kubectl delete redisfailover <NAME>
 [![Redis Operator Image](https://ghcr.io/freshworks/redis-operator/status "Redis Operator Image")](https://ghcr.io/freshworks/redis-operator)
 ## Documentation
 
-For the code documentation, you can lookup on the [GoDoc](https://godoc.org/github.com/freshworks/redis-operator).
+For the code documentation, see [pkg.go.dev](https://pkg.go.dev/github.com/freshworks/redis-operator).
+
+**Maintainers:** release **playbook** (operator-only vs CRD): [docs/releasing.md](docs/releasing.md). **Process / CI details** and validation when you change that process: [docs/release-process-internals.md](docs/release-process-internals.md).
 
 Also, you can check more deeply information on the [docs folder](docs).

--- a/charts/chart-release-config.yaml
+++ b/charts/chart-release-config.yaml
@@ -1,1 +1,0 @@
-release-name-template: Chart-{{ .Version }}

--- a/charts/redisoperator/Chart.yaml
+++ b/charts/redisoperator/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   category: Redis Operator
 appVersion: 1.3.0
 apiVersion: v1
-description: A Helm chart for the Spotahome Redis Operator
+description: A Helm chart for the Redis Operator
 name: redis-operator
 version: 3.3.3
 home: https://github.com/freshworks/redis-operator

--- a/charts/redisoperator/values.yaml
+++ b/charts/redisoperator/values.yaml
@@ -4,7 +4,7 @@
 
 # Name of the image repository to pull the container image from.
 image:
-  repository: quay.io/spotahome/redis-operator
+  repository: ghcr.io/freshworks/redis-operator
   pullPolicy: IfNotPresent
   tag: v1.3.0
   cli_args: ""

--- a/docs/release-process-internals.md
+++ b/docs/release-process-internals.md
@@ -1,0 +1,52 @@
+# Release process (internals)
+
+This document describes **how automation is wired**, what to **verify** when you change workflows or release steps, and how to **test** end-to-end without mixing that into the [releasing playbook](releasing.md).
+
+For **step-by-step “what do I do for a new release?”** (operator-only vs CRD), use [releasing.md](releasing.md) only.
+
+---
+
+## Workflows (what runs when)
+
+| Workflow | File | Trigger (summary) | What it does |
+|----------|------|---------------------|--------------|
+| **Create a release** | [.github/workflows/release.yml](../.github/workflows/release.yml) | `release: types: [published]` | On a **published** GitHub Release, checks out the tag, runs `make image-release` and pushes **multi-arch operator images** to `ghcr.io` (see [Makefile](../Makefile) `image-release`, `REPOSITORY` / `IMAGE_NAME`). **Does not** create tags; you create the tag and Release. |
+| **Release Charts** | [.github/workflows/helm.yml](../.github/workflows/helm.yml) | **Push to `master`** with paths under `charts/**` only (not the workflow file alone) | `helm package` for `charts/redisoperator`, `helm registry login` to GHCR, `helm push` to `oci://ghcr.io/<repository_owner>/charts`. Chart **version** is whatever is in [Chart.yaml](charts/redisoperator/Chart.yaml) at that commit. |
+| **CI** (incl. version check) | [.github/workflows/ci.yaml](../.github/workflows/ci.yaml) | **Pull requests** to `master` (and push per file) | Lint, unit tests, optional integration, Helm `lint`/`template`, and **if the CRD manifest file changed**, **version-check** enforces a bump to [Chart.yaml](charts/redisoperator/Chart.yaml) `version` vs the base branch. |
+| **Release Drafter** | [.github/workflows/draft_release.yml](../.github/workflows/draft_release.yml) + [.github/release-drafter.yml](../.github/release-drafter.yml) | Pushes to `main` / `master` | Updates a **draft** release body from merged PRs and labels. Does **not** change repo versions or push images. |
+
+**Important:** A **PR branch** does not run the **Helm OCI** push; that only runs after merge to `master` and a change under `charts/**`.
+
+**Makefile (operator tag selection):** `image-release` tags images with `$(TAG)` derived from git: latest tag if `HEAD` matches that tag, else commit SHA (and `-dirty` if the tree is not clean). The `release` workflow runs on the tagged tree, so the tag is usually a SemVer `v*`.
+
+---
+
+## When you change the release process (what to test)
+
+If you modify [.github/workflows/release.yml](../.github/workflows/release.yml), [helm.yml](../.github/workflows/helm.yml), [ci.yaml](../.github/workflows/ci.yaml), or the Makefile’s image/push targets:
+
+1. **Run local equivalents** on a branch: `make ci-lint`, `make ci-unit-test`, `make helm-test`.  
+2. **Operator image path** — in a **fork** (or disposable repo with Actions enabled), create a **test tag** and a **pre-release** GitHub Release, confirm the workflow completes and:  
+   `docker pull ghcr.io/<org>/redis-operator:<test-tag>`.  
+3. **Helm OCI path** — merge a change under `charts/**` to the fork’s `master` (or `helm package` + `helm registry login` + `helm push` manually) and run:  
+   `helm show chart oci://ghcr.io/<org>/charts/redis-operator --version <Chart version>`.  
+4. **Version-check** — if you still change the CRD file in a PR, confirm the `version-check` job passes only when [Chart.yaml](charts/redisoperator/Chart.yaml) `version` is bumped correctly, and fails when it is not.
+
+---
+
+## Pre-merge and fork testing (PR validation)
+
+- **On the PR to upstream:** default CI runs lint, tests, and (per path filters) integration and chart checks. **version-check** runs if the CRD file changed.  
+- **What the PR does not do:** it does not run `helm push` to production GHCR until you merge.  
+- **To validate OCI / Actions before merge to the main org:** use a **fork**, enable **Actions**, push/merge to the fork’s `master` with `charts/**` changes so [helm.yml](../.github/workflows/helm.yml) runs against your `repository_owner`. For the operator image, use a **test tag** and **pre-release** on the fork.  
+- **Pushing the same chart `version` again:** a second `helm push` of the same chart `version` may be accepted (overwrite) or rejected by the registry, depending on GHCR/OCI policy—always **bump [Chart.yaml](charts/redisoperator/Chart.yaml) `version`** for a new chart you intend to be a distinct published version.
+
+**Local `helm` without a registry** — install from path for smoke tests:  
+`helm install testrel ./charts/redisoperator` (suitable for Kind/minikube; uninstall when done).
+
+---
+
+## Cross-links
+
+- [releasing.md](releasing.md) — maintainer release playbook.  
+- [README: deployment](../README.md#operator-deployment-on-kubernetes) — `kubectl`, Kustomize, and Helm OCI for users.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,68 @@
+# Releasing (playbook)
+
+For **maintainers**: what to do when you cut a release. **SemVer and chart versions are edited by hand**—there is no automatic version bump in this repository.
+
+**Process details** (workflows, CI behavior, and how to test a change to that process): [release-process-internals.md](release-process-internals.md)
+
+---
+
+## What to bump in each situation
+
+| What changed | Bump Git tag (operator) | Bump [Chart.yaml](charts/redisoperator/Chart.yaml) `version` | Update chart [values](charts/redisoperator/values.yaml) `image.tag` (and often `appVersion`) |
+|--------------|-------------------------|-------------------------------------------------------------|-----------------------------------------------------------------------------------------------|
+| **Operator code / behavior only** (no CRD YAML) | **Yes** — new `vX.Y.Z` for the image | **Only if** you publish a **new** Helm chart (see below) | **Yes** if the chart’s default image should follow the new operator |
+| **CRD** ([manifests/databases…](../manifests/databases.spotahome.com_redisfailovers.yaml) and [chart copy](../charts/redisoperator/crds/)) | Yes, when you release that operator | **Yes** — CI on PRs will fail without a valid chart `version` bump | Usually yes so defaults stay consistent |
+| **Helm templates / values only** (operator binary unchanged) | No new tag required unless you also ship a new image | **Yes** for any new chart you `helm push` | Only if the image reference changes |
+
+The Kubernetes **API group** stays `databases.spotahome.com` in normal releases (see [README](../README.md)).
+
+---
+
+## A. Operator-only release (no CRD file change)
+
+Typical case: changes under `operator/`, `cmd/`, `service/`, etc. **The CRD file is untouched.**
+
+1. **Merge** your work to `master` when CI is green. Local sanity: `make ci-lint`, `make ci-unit-test`, and `make helm-test` from the repo root.
+2. **Tag** the commit you are releasing (e.g. `v1.4.0`) using your SemVer policy.
+3. **Create a GitHub Release** from that tag and **publish** it. That triggers the **Create a release** workflow, which builds and pushes the **operator image** to GHCR. Confirm the run succeeds and the image is listed under the org’s packages.
+4. **Chart and Helm on GHCR**  
+   - Pushing a **new** OCI chart to GHCR only happens when there is a **push to `master` that changes something under** `charts/**` (see [release-process-internals.md](release-process-internals.md#workflows)).  
+   - If users should `helm install` a chart whose **defaults** use the new image: in the same release cycle (or a follow-up PR to `master`), bump [Chart.yaml](charts/redisoperator/Chart.yaml) `version`, set [values.yaml](charts/redisoperator/values.yaml) `image.tag` (and `appVersion` / `app.kubernetes.io` labels if you use them) to match the new tag, then **merge** so the chart workflow runs.  
+   - If you **do not** change `charts/**`, the operator image is still available by tag, but the published Helm chart in GHCR (if any) is unchanged—users can override `image.tag` or wait for a later chart update.
+
+5. **Notes / changelog** — update [CHANGELOG.md](../CHANGELOG.md) and release notes to match your project policy (Release Drafter can pre-fill drafts).
+
+---
+
+## B. CRD change (or you ship a new operator that includes CRD updates)
+
+**Any change** to the canonical CRD, e.g. [manifests/databases.spotahome.com_redisfailovers.yaml](../manifests/databases.spotahome.com_redisfailovers.yaml), also requires:
+
+1. **Keep the chart copy in sync** — the chart bundles CRDs under [charts/redisoperator/crds/](../charts/redisoperator/crds/); follow the same content as the manifest the project treats as source of truth (and [kustomize base](../manifests/kustomize/base) if that is your flow).
+2. **Bump the Helm chart `version`** in [Chart.yaml](charts/redisoperator/Chart.yaml) in the **same PR** (valid patch/minor/major per policy). A PR that changes the CRD file without a chart version bump will **fail** the **version-check** job in CI.
+3. **Operator image** — as in section A: tag, GitHub Release, confirm image in GHCR.
+4. **Clusters** — document or perform **CRD application** (often `kubectl replace` / `kubectl apply` of the CRD) per [README](../README.md#update-helm-chart) so existing clusters pick up the new schema. Communicate any required user actions in release notes.
+5. **Merge to `master`**; if `charts/**` changed, the **Release Charts** workflow publishes the new chart OCI version to GHCR.
+
+---
+
+## Short checklists
+
+**Before tagging an operator release**
+
+- [ ] Tests and lint pass on the commit you are tagging.  
+- [ ] CRD and chart `crds/` are in sync if you touched the CRD.  
+- [ ] [Chart.yaml](charts/redisoperator/Chart.yaml) `version` is bumped on the PR if the CRD file changed.  
+- [ ] Release notes / CHANGELOG ready (or use Release Drafter as a start).
+
+**After the GitHub Release is published**
+
+- [ ] Operator image exists in GHCR for the new tag.  
+- [ ] If the chart was updated: new chart `version` appears in GHCR under GitHub Packages; `helm show chart` / `helm install … --version` work as in the README.
+
+---
+
+## Further reading (end users and install commands)
+
+- [README: operator deployment and Helm OCI](../README.md#operator-deployment-on-kubernetes)  
+- [Helm: Chart `version` vs `appVersion`](https://helm.sh/docs/topics/charts/#the-chartyaml-file)

--- a/example/operator/all-redis-operator-resources.yaml
+++ b/example/operator/all-redis-operator-resources.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       serviceAccountName: redisoperator
       containers:
-        - image: quay.io/spotahome/redis-operator:latest
+        - image: ghcr.io/freshworks/redis-operator:latest
           imagePullPolicy: IfNotPresent
           name: app
           securityContext:

--- a/example/operator/operator.yaml
+++ b/example/operator/operator.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       serviceAccountName: redisoperator
       containers:
-      - image: quay.io/spotahome/redis-operator:latest
+      - image: ghcr.io/freshworks/redis-operator:latest
         imagePullPolicy: IfNotPresent
         name: app
         securityContext:

--- a/manifests/kustomize/base/deployment.yaml
+++ b/manifests/kustomize/base/deployment.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: redis-operator
-          image: quay.io/spotahome/redis-operator:latest
+          image: ghcr.io/freshworks/redis-operator:latest
           imagePullPolicy: IfNotPresent
           securityContext:
             readOnlyRootFilesystem: true

--- a/manifests/kustomize/components/version/kustomization.yaml
+++ b/manifests/kustomize/components/version/kustomization.yaml
@@ -6,5 +6,5 @@ labels:
       app.kubernetes.io/version: 1.3.0
 
 images:
-  - name: quay.io/spotahome/redis-operator
+  - name: ghcr.io/freshworks/redis-operator
     newTag: v1.3.0


### PR DESCRIPTION
## Summary

Align install docs and defaults with **Freshworks** and **GHCR**: Helm installs use **OCI** (`oci://ghcr.io/...`) only (no gh-pages / chart-releaser). Operator examples and chart default image use `ghcr.io/freshworks/redis-operator`.

## Changes

- **CI (`.github/workflows/helm.yml`)**: Publish Helm chart with `helm package` + `helm push` to GHCR; `helm registry login`; trigger only on `charts/**`; remove chart-releaser and `charts/chart-release-config.yaml`.
- **Docs**: README / CHANGELOG updated for Freshworks URLs and OCI Helm instructions; API group vs Freshworks branding note; maintainer [docs/releasing.md](docs/releasing.md) (playbook) and [docs/release-process-internals.md](docs/release-process-internals.md) (CI/process details).
- **Charts / examples / Kustomize**: Default operator image `ghcr.io/freshworks/redis-operator`; Chart description cleanup.

## Testing

- `make helm-test` (helm lint + template) passes locally.

## Notes for reviewers

- Chart OCI URL in CI uses GitHub `repository_owner`; README examples use `freshworks`—adjust if the canonical org differs (e.g. `freshworks-oss`).
- After merge: optionally delete legacy **gh-pages** branch if unused.