### PR TITLE
Valkey adoption in operator codebase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ SHELL := $(shell which bash)
 # Local builds use Podman when available, otherwise Docker. Override explicitly,
 # e.g. `make CONTAINER_ENGINE=docker image` when both are installed.
 CONTAINER_ENGINE ?= $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
+# Non-empty when CONTAINER_ENGINE points at Podman (path may be .../bin/podman).
+IS_PODMAN := $(findstring podman,$(CONTAINER_ENGINE))
 
 # Get the main unix group for the user running make (to be used by docker-compose later)
 GID := $(shell id -g)
@@ -101,8 +103,24 @@ image: deps-development
 	-f $(APP_DIR)/Dockerfile \
 	.
 
-# Multi-arch push needs `buildx` (Docker Buildx, or Podman 4.3+ with buildx support).
+# Multi-arch registry push uses Docker Buildx. Podman does not support the same
+# `buildx build --push` flow; with Podman we build for the current architecture and
+# push tags with `podman push` (same as `docker push`).
 .PHONY: image-release
+ifneq ($(IS_PODMAN),)
+image-release:
+	@echo ">> image-release: using Podman (single-arch build + podman push). For multi-arch use Docker: make CONTAINER_ENGINE=docker image-release"
+	$(CONTAINER_ENGINE) build \
+	--build-arg VERSION=$(TAG) \
+	-t $(REPOSITORY):latest \
+	-t $(REPOSITORY):$(COMMIT) \
+	-t $(REPOSITORY):$(TAG) \
+	-f $(APP_DIR)/Dockerfile \
+	.
+	$(CONTAINER_ENGINE) push $(REPOSITORY):latest
+	$(CONTAINER_ENGINE) push $(REPOSITORY):$(COMMIT)
+	$(CONTAINER_ENGINE) push $(REPOSITORY):$(TAG)
+else
 image-release:
 	$(CONTAINER_ENGINE) buildx build \
 	--platform linux/amd64,linux/arm64,linux/arm/v7 \
@@ -113,6 +131,7 @@ image-release:
 	-t $(REPOSITORY):$(TAG) \
 	-f $(APP_DIR)/Dockerfile \
 	.
+endif
 
 .PHONY: testing
 testing: image

--- a/Makefile
+++ b/Makefile
@@ -103,23 +103,22 @@ image: deps-development
 	-f $(APP_DIR)/Dockerfile \
 	.
 
-# Multi-arch registry push uses Docker Buildx. Podman does not support the same
-# `buildx build --push` flow; with Podman we build for the current architecture and
-# push tags with `podman push` (same as `docker push`).
+# Multi-arch registry push:
+# - Docker uses Buildx with `--push`.
+# - Podman uses manifest lists (`podman build --manifest` + `podman manifest push --all`).
 .PHONY: image-release
 ifneq ($(IS_PODMAN),)
 image-release:
-	@echo ">> image-release: using Podman (single-arch build + podman push). For multi-arch use Docker: make CONTAINER_ENGINE=docker image-release"
+	@echo ">> image-release: using Podman manifest-based multi-arch build and push"
 	$(CONTAINER_ENGINE) build \
+	--platform linux/amd64,linux/arm64,linux/arm/v7 \
+	--manifest $(REPOSITORY):$(TAG) \
 	--build-arg VERSION=$(TAG) \
-	-t $(REPOSITORY):latest \
-	-t $(REPOSITORY):$(COMMIT) \
-	-t $(REPOSITORY):$(TAG) \
 	-f $(APP_DIR)/Dockerfile \
 	.
-	$(CONTAINER_ENGINE) push $(REPOSITORY):latest
-	$(CONTAINER_ENGINE) push $(REPOSITORY):$(COMMIT)
-	$(CONTAINER_ENGINE) push $(REPOSITORY):$(TAG)
+	$(CONTAINER_ENGINE) manifest push --all $(REPOSITORY):$(TAG) docker://$(REPOSITORY):$(TAG)
+	$(CONTAINER_ENGINE) manifest push --all $(REPOSITORY):$(TAG) docker://$(REPOSITORY):$(COMMIT)
+	$(CONTAINER_ENGINE) manifest push --all $(REPOSITORY):$(TAG) docker://$(REPOSITORY):latest
 else
 image-release:
 	$(CONTAINER_ENGINE) buildx build \

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 [![Build Status](https://github.com/freshworks/redis-operator/actions/workflows/ci.yaml/badge.svg?branch=master)](https://github.com/freshworks/redis-operator)
 [![Go Report Card](https://goreportcard.com/badge/github.com/freshworks/redis-operator)](https://goreportcard.com/report/github.com/freshworks/redis-operator)
 
-Redis Operator creates/configures/manages redis-failovers atop Kubernetes.
+Redis Operator creates/configures/manages highly available Redis or Valkey failovers with Sentinel automatic failover atop Kubernetes.
+
+- Supports both **Redis** and **Valkey** engines (selectable via `spec.engine`).
 
 This project is licensed under the [Apache License 2.0](LICENSE).
 

--- a/api/redisfailover/v1/defaults.go
+++ b/api/redisfailover/v1/defaults.go
@@ -5,7 +5,8 @@ const (
 	defaultSentinelNumber           = 3
 	defaultSentinelExporterImage    = "quay.io/oliver006/redis_exporter:v1.43.0"
 	defaultExporterImage            = "quay.io/oliver006/redis_exporter:v1.43.0"
-	defaultImage                    = "redis:6.2.6-alpine"
+	defaultImage                    = "redis:7.2.4-alpine"
+	defaultValkeyImage              = "valkey/valkey:7.2.11-alpine"
 	defaultRedisPort                = 6379
 	defaultReservedPodMemoryPercent = 10
 )

--- a/api/redisfailover/v1/engine_image_hint.go
+++ b/api/redisfailover/v1/engine_image_hint.go
@@ -1,0 +1,45 @@
+package v1
+
+import "strings"
+
+// imageNameSuggestsRedisOrValkey is a loose substring check for typical Redis/Valkey image names.
+func imageNameSuggestsRedisOrValkey(lower string) bool {
+	return strings.Contains(lower, "redis") || strings.Contains(lower, "valkey")
+}
+
+// DatabaseEngineImageMismatchHints returns soft UX messages when spec.databaseEngine and
+// explicit image references look inconsistent under a simple naming heuristic (substring).
+// This does not reject applies; registry paths and mirror names may legitimately omit "valkey"/"redis".
+func DatabaseEngineImageMismatchHints(rf *RedisFailover) []string {
+	if rf == nil {
+		return nil
+	}
+	var hints []string
+	eng := rf.Spec.DatabaseEngine
+	ri := strings.ToLower(rf.Spec.Redis.Image)
+	si := strings.ToLower(rf.Spec.Sentinel.Image)
+
+	if eng == DatabaseEngineValkey {
+		if rf.Spec.Redis.Image != "" && !strings.Contains(ri, "valkey") {
+			hints = append(hints, `spec.redis.image does not contain "valkey"; use a Valkey image or set spec.redis.command to match binaries inside the image`)
+		}
+		if rf.Spec.Sentinel.Image != "" && !strings.Contains(si, "valkey") {
+			hints = append(hints, `spec.sentinel.image does not contain "valkey"; use a Valkey image or set spec.sentinel.command to match binaries inside the image`)
+		}
+	}
+	if eng == "" || eng == DatabaseEngineRedis {
+		if rf.Spec.Redis.Image != "" && strings.Contains(ri, "valkey") {
+			hints = append(hints, `spec.redis.image appears to be Valkey but databaseEngine is Redis or unset; set databaseEngine: Valkey or use a Redis image`)
+		}
+		if rf.Spec.Sentinel.Image != "" && strings.Contains(si, "valkey") {
+			hints = append(hints, `spec.sentinel.image appears to be Valkey but databaseEngine is Redis or unset; set databaseEngine: Valkey or use a Redis image`)
+		}
+		if rf.Spec.Redis.Image != "" && !imageNameSuggestsRedisOrValkey(ri) {
+			hints = append(hints, `spec.redis.image does not contain "redis" or "valkey"; confirm the image matches databaseEngine (Redis protocol) and supplies redis-server/redis-cli or override command`)
+		}
+		if rf.Spec.Sentinel.Image != "" && !imageNameSuggestsRedisOrValkey(si) {
+			hints = append(hints, `spec.sentinel.image does not contain "redis" or "valkey"; confirm the image matches databaseEngine and supplies redis-server for sentinel mode or override command`)
+		}
+	}
+	return hints
+}

--- a/api/redisfailover/v1/engine_image_hint.go
+++ b/api/redisfailover/v1/engine_image_hint.go
@@ -7,7 +7,7 @@ func imageNameSuggestsRedisOrValkey(lower string) bool {
 	return strings.Contains(lower, "redis") || strings.Contains(lower, "valkey")
 }
 
-// DatabaseEngineImageMismatchHints returns soft UX messages when spec.databaseEngine and
+// DatabaseEngineImageMismatchHints returns soft UX messages when spec.engine and
 // explicit image references look inconsistent under a simple naming heuristic (substring).
 // This does not reject applies; registry paths and mirror names may legitimately omit "valkey"/"redis".
 func DatabaseEngineImageMismatchHints(rf *RedisFailover) []string {
@@ -15,11 +15,11 @@ func DatabaseEngineImageMismatchHints(rf *RedisFailover) []string {
 		return nil
 	}
 	var hints []string
-	eng := rf.Spec.DatabaseEngine
+	eng := rf.Spec.Engine
 	ri := strings.ToLower(rf.Spec.Redis.Image)
 	si := strings.ToLower(rf.Spec.Sentinel.Image)
 
-	if eng == DatabaseEngineValkey {
+	if eng == ValkeyEngine {
 		if rf.Spec.Redis.Image != "" && !strings.Contains(ri, "valkey") {
 			hints = append(hints, `spec.redis.image does not contain "valkey"; use a Valkey image or set spec.redis.command to match binaries inside the image`)
 		}
@@ -27,18 +27,18 @@ func DatabaseEngineImageMismatchHints(rf *RedisFailover) []string {
 			hints = append(hints, `spec.sentinel.image does not contain "valkey"; use a Valkey image or set spec.sentinel.command to match binaries inside the image`)
 		}
 	}
-	if eng == "" || eng == DatabaseEngineRedis {
+	if eng == "" || eng == RedisEngine {
 		if rf.Spec.Redis.Image != "" && strings.Contains(ri, "valkey") {
-			hints = append(hints, `spec.redis.image appears to be Valkey but databaseEngine is Redis or unset; set databaseEngine: Valkey or use a Redis image`)
+			hints = append(hints, `spec.redis.image appears to be Valkey but engine is Redis or unset; set engine: Valkey or use a Redis image`)
 		}
 		if rf.Spec.Sentinel.Image != "" && strings.Contains(si, "valkey") {
-			hints = append(hints, `spec.sentinel.image appears to be Valkey but databaseEngine is Redis or unset; set databaseEngine: Valkey or use a Redis image`)
+			hints = append(hints, `spec.sentinel.image appears to be Valkey but engine is Redis or unset; set engine: Valkey or use a Redis image`)
 		}
 		if rf.Spec.Redis.Image != "" && !imageNameSuggestsRedisOrValkey(ri) {
-			hints = append(hints, `spec.redis.image does not contain "redis" or "valkey"; confirm the image matches databaseEngine (Redis protocol) and supplies redis-server/redis-cli or override command`)
+			hints = append(hints, `spec.redis.image does not contain "redis" or "valkey"; confirm the image matches engine (Redis protocol) and supplies redis-server/redis-cli or override command`)
 		}
 		if rf.Spec.Sentinel.Image != "" && !imageNameSuggestsRedisOrValkey(si) {
-			hints = append(hints, `spec.sentinel.image does not contain "redis" or "valkey"; confirm the image matches databaseEngine and supplies redis-server for sentinel mode or override command`)
+			hints = append(hints, `spec.sentinel.image does not contain "redis" or "valkey"; confirm the image matches engine and supplies redis-server for sentinel mode or override command`)
 		}
 	}
 	return hints

--- a/api/redisfailover/v1/engine_image_hint_test.go
+++ b/api/redisfailover/v1/engine_image_hint_test.go
@@ -1,0 +1,124 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDatabaseEngineImageMismatchHints(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		rf   *RedisFailover
+		want int // number of hints expected
+	}{
+		{
+			name: "nil",
+			rf:   nil,
+			want: 0,
+		},
+		{
+			name: "defaults only no explicit images",
+			rf: &RedisFailover{
+				Spec: RedisFailoverSpec{
+					DatabaseEngine: DatabaseEngineValkey,
+				},
+			},
+			want: 0,
+		},
+		{
+			name: "Valkey engine redis images",
+			rf: &RedisFailover{
+				Spec: RedisFailoverSpec{
+					DatabaseEngine: DatabaseEngineValkey,
+					Redis: RedisSettings{
+						Image: "redis:7-alpine",
+					},
+					Sentinel: SentinelSettings{
+						Image: "redis:7-alpine",
+					},
+				},
+			},
+			want: 2,
+		},
+		{
+			name: "Valkey engine matching images",
+			rf: &RedisFailover{
+				Spec: RedisFailoverSpec{
+					DatabaseEngine: DatabaseEngineValkey,
+					Redis: RedisSettings{
+						Image: "valkey/valkey:8",
+					},
+					Sentinel: SentinelSettings{
+						Image: "valkey/valkey:8",
+					},
+				},
+			},
+			want: 0,
+		},
+		{
+			name: "Redis engine valkey images",
+			rf: &RedisFailover{
+				Spec: RedisFailoverSpec{
+					DatabaseEngine: DatabaseEngineRedis,
+					Redis: RedisSettings{
+						Image: "valkey/valkey:8",
+					},
+					Sentinel: SentinelSettings{
+						Image: "valkey/valkey:8",
+					},
+				},
+			},
+			want: 2,
+		},
+		{
+			name: "unset engine valkey redis image only",
+			rf: &RedisFailover{
+				Spec: RedisFailoverSpec{
+					Redis: RedisSettings{
+						Image: "valkey/valkey:8",
+					},
+				},
+			},
+			want: 1,
+		},
+		{
+			name: "Redis engine custom image without redis or valkey in name",
+			rf: &RedisFailover{
+				Spec: RedisFailoverSpec{
+					DatabaseEngine: DatabaseEngineRedis,
+					Redis: RedisSettings{
+						Image: "myregistry.io/team/cache-runner:v2",
+					},
+					Sentinel: SentinelSettings{
+						Image: "myregistry.io/team/cache-runner:v2",
+					},
+				},
+			},
+			want: 2,
+		},
+		{
+			name: "Redis engine explicit redis image no hints",
+			rf: &RedisFailover{
+				Spec: RedisFailoverSpec{
+					DatabaseEngine: DatabaseEngineRedis,
+					Redis: RedisSettings{
+						Image: "redis:7-alpine",
+					},
+					Sentinel: SentinelSettings{
+						Image: "redis:7-alpine",
+					},
+				},
+			},
+			want: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := DatabaseEngineImageMismatchHints(tt.rf)
+			assert.Len(t, got, tt.want)
+		})
+	}
+}

--- a/api/redisfailover/v1/engine_image_hint_test.go
+++ b/api/redisfailover/v1/engine_image_hint_test.go
@@ -22,7 +22,7 @@ func TestDatabaseEngineImageMismatchHints(t *testing.T) {
 			name: "defaults only no explicit images",
 			rf: &RedisFailover{
 				Spec: RedisFailoverSpec{
-					DatabaseEngine: DatabaseEngineValkey,
+					Engine: ValkeyEngine,
 				},
 			},
 			want: 0,
@@ -31,7 +31,7 @@ func TestDatabaseEngineImageMismatchHints(t *testing.T) {
 			name: "Valkey engine redis images",
 			rf: &RedisFailover{
 				Spec: RedisFailoverSpec{
-					DatabaseEngine: DatabaseEngineValkey,
+					Engine: ValkeyEngine,
 					Redis: RedisSettings{
 						Image: "redis:7-alpine",
 					},
@@ -46,7 +46,7 @@ func TestDatabaseEngineImageMismatchHints(t *testing.T) {
 			name: "Valkey engine matching images",
 			rf: &RedisFailover{
 				Spec: RedisFailoverSpec{
-					DatabaseEngine: DatabaseEngineValkey,
+					Engine: ValkeyEngine,
 					Redis: RedisSettings{
 						Image: "valkey/valkey:8",
 					},
@@ -61,7 +61,7 @@ func TestDatabaseEngineImageMismatchHints(t *testing.T) {
 			name: "Redis engine valkey images",
 			rf: &RedisFailover{
 				Spec: RedisFailoverSpec{
-					DatabaseEngine: DatabaseEngineRedis,
+					Engine: RedisEngine,
 					Redis: RedisSettings{
 						Image: "valkey/valkey:8",
 					},
@@ -87,7 +87,7 @@ func TestDatabaseEngineImageMismatchHints(t *testing.T) {
 			name: "Redis engine custom image without redis or valkey in name",
 			rf: &RedisFailover{
 				Spec: RedisFailoverSpec{
-					DatabaseEngine: DatabaseEngineRedis,
+					Engine: RedisEngine,
 					Redis: RedisSettings{
 						Image: "myregistry.io/team/cache-runner:v2",
 					},
@@ -102,7 +102,7 @@ func TestDatabaseEngineImageMismatchHints(t *testing.T) {
 			name: "Redis engine explicit redis image no hints",
 			rf: &RedisFailover{
 				Spec: RedisFailoverSpec{
-					DatabaseEngine: DatabaseEngineRedis,
+					Engine: RedisEngine,
 					Redis: RedisSettings{
 						Image: "redis:7-alpine",
 					},

--- a/api/redisfailover/v1/types.go
+++ b/api/redisfailover/v1/types.go
@@ -5,6 +5,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// DatabaseEngine selects which Redis-compatible engine backs this failover.
+// Omit or use Redis for standard Redis. Use Valkey for Valkey images and binaries.
+type DatabaseEngine string
+
+const (
+	// DatabaseEngineRedis is the default when databaseEngine is omitted or empty.
+	DatabaseEngineRedis  DatabaseEngine = "Redis"
+	DatabaseEngineValkey DatabaseEngine = "Valkey"
+)
+
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
@@ -22,6 +32,10 @@ type RedisFailover struct {
 
 // RedisFailoverSpec represents a Redis failover spec
 type RedisFailoverSpec struct {
+	// DatabaseEngine selects Redis or Valkey. Omitted or empty means Redis (historical behavior).
+	// +optional
+	// +kubebuilder:validation:Enum=Redis;Valkey
+	DatabaseEngine DatabaseEngine     `json:"databaseEngine,omitempty"`
 	Redis          RedisSettings      `json:"redis,omitempty"`
 	Sentinel       SentinelSettings   `json:"sentinel,omitempty"`
 	Auth           AuthSettings       `json:"auth,omitempty"`

--- a/api/redisfailover/v1/types.go
+++ b/api/redisfailover/v1/types.go
@@ -10,9 +10,9 @@ import (
 type DatabaseEngine string
 
 const (
-	// DatabaseEngineRedis is the default when databaseEngine is omitted or empty.
-	DatabaseEngineRedis  DatabaseEngine = "Redis"
-	DatabaseEngineValkey DatabaseEngine = "Valkey"
+	// RedisEngine is the default when engine is omitted or empty.
+	RedisEngine  DatabaseEngine = "Redis"
+	ValkeyEngine DatabaseEngine = "Valkey"
 )
 
 // +genclient
@@ -32,10 +32,10 @@ type RedisFailover struct {
 
 // RedisFailoverSpec represents a Redis failover spec
 type RedisFailoverSpec struct {
-	// DatabaseEngine selects Redis or Valkey. Omitted or empty means Redis (historical behavior).
+	// Engine selects Redis or Valkey. Omitted or empty means Redis (historical behavior).
 	// +optional
 	// +kubebuilder:validation:Enum=Redis;Valkey
-	DatabaseEngine DatabaseEngine     `json:"databaseEngine,omitempty"`
+	Engine         DatabaseEngine     `json:"engine,omitempty"`
 	Redis          RedisSettings      `json:"redis,omitempty"`
 	Sentinel       SentinelSettings   `json:"sentinel,omitempty"`
 	Auth           AuthSettings       `json:"auth,omitempty"`

--- a/api/redisfailover/v1/validate.go
+++ b/api/redisfailover/v1/validate.go
@@ -16,14 +16,14 @@ func (r *RedisFailover) Validate() error {
 		return fmt.Errorf("name length can't be higher than %d", maxNameLength)
 	}
 
-	switch r.Spec.DatabaseEngine {
-	case "", DatabaseEngineRedis, DatabaseEngineValkey:
+	switch r.Spec.Engine {
+	case "", RedisEngine, ValkeyEngine:
 	default:
-		return fmt.Errorf("invalid databaseEngine %q, must be Redis, Valkey, or omitted", r.Spec.DatabaseEngine)
+		return fmt.Errorf("invalid engine %q, must be Redis, Valkey, or omitted", r.Spec.Engine)
 	}
 
 	defaultImageForEngine := defaultImage
-	if r.Spec.DatabaseEngine == DatabaseEngineValkey {
+	if r.Spec.Engine == ValkeyEngine {
 		defaultImageForEngine = defaultValkeyImage
 	}
 

--- a/api/redisfailover/v1/validate.go
+++ b/api/redisfailover/v1/validate.go
@@ -16,6 +16,17 @@ func (r *RedisFailover) Validate() error {
 		return fmt.Errorf("name length can't be higher than %d", maxNameLength)
 	}
 
+	switch r.Spec.DatabaseEngine {
+	case "", DatabaseEngineRedis, DatabaseEngineValkey:
+	default:
+		return fmt.Errorf("invalid databaseEngine %q, must be Redis, Valkey, or omitted", r.Spec.DatabaseEngine)
+	}
+
+	defaultImageForEngine := defaultImage
+	if r.Spec.DatabaseEngine == DatabaseEngineValkey {
+		defaultImageForEngine = defaultValkeyImage
+	}
+
 	if r.Bootstrapping() {
 		if r.Spec.BootstrapNode.Host == "" {
 			return errors.New("BootstrapNode must include a host when provided")
@@ -30,11 +41,11 @@ func (r *RedisFailover) Validate() error {
 	}
 
 	if r.Spec.Redis.Image == "" {
-		r.Spec.Redis.Image = defaultImage
+		r.Spec.Redis.Image = defaultImageForEngine
 	}
 
 	if r.Spec.Sentinel.Image == "" {
-		r.Spec.Sentinel.Image = defaultImage
+		r.Spec.Sentinel.Image = defaultImageForEngine
 	}
 
 	if r.Spec.Redis.Replicas <= 0 {

--- a/api/redisfailover/v1/validate_test.go
+++ b/api/redisfailover/v1/validate_test.go
@@ -11,6 +11,7 @@ func TestValidate(t *testing.T) {
 	tests := []struct {
 		name                   string
 		rfName                 string
+		rfDatabaseEngine       DatabaseEngine
 		rfBootstrapNode        *BootstrapSettings
 		rfRedisCustomConfig    []string
 		rfSentinelCustomConfig []string
@@ -25,6 +26,17 @@ func TestValidate(t *testing.T) {
 			name:          "errors on too long of name",
 			rfName:        "some-super-absurdely-unnecessarily-long-name-that-will-most-definitely-fail",
 			expectedError: "name length can't be higher than 48",
+		},
+		{
+			name:             "errors on invalid databaseEngine",
+			rfName:           "test",
+			rfDatabaseEngine: DatabaseEngine("Other"),
+			expectedError:    "invalid databaseEngine",
+		},
+		{
+			name:             "Valkey engine uses default Valkey image",
+			rfName:           "test",
+			rfDatabaseEngine: DatabaseEngineValkey,
 		},
 		{
 			name:                   "SentinelCustomConfig provided",
@@ -71,6 +83,7 @@ func TestValidate(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			assert := assert.New(t)
 			rf := generateRedisFailover(test.rfName, test.rfBootstrapNode)
+			rf.Spec.DatabaseEngine = test.rfDatabaseEngine
 			rf.Spec.Redis.CustomConfig = test.rfRedisCustomConfig
 			rf.Spec.Sentinel.CustomConfig = test.rfSentinelCustomConfig
 
@@ -78,6 +91,11 @@ func TestValidate(t *testing.T) {
 
 			if test.expectedError == "" {
 				assert.NoError(err)
+
+				defaultImg := defaultImage
+				if test.rfDatabaseEngine == DatabaseEngineValkey {
+					defaultImg = defaultValkeyImage
+				}
 
 				expectedRedisCustomConfig := []string{
 					"replica-priority 100",
@@ -101,8 +119,9 @@ func TestValidate(t *testing.T) {
 						Namespace: "namespace",
 					},
 					Spec: RedisFailoverSpec{
+						DatabaseEngine: test.rfDatabaseEngine,
 						Redis: RedisSettings{
-							Image:                    defaultImage,
+							Image:                    defaultImg,
 							Replicas:                 defaultRedisNumber,
 							Port:                     defaultRedisPort,
 							ReservedPodMemoryPercent: defaultReservedPodMemoryPercent,
@@ -112,7 +131,7 @@ func TestValidate(t *testing.T) {
 							CustomConfig: expectedRedisCustomConfig,
 						},
 						Sentinel: SentinelSettings{
-							Image:        defaultImage,
+							Image:        defaultImg,
 							Replicas:     defaultSentinelNumber,
 							CustomConfig: expectedSentinelCustomConfig,
 							Exporter: Exporter{
@@ -125,7 +144,7 @@ func TestValidate(t *testing.T) {
 				assert.Equal(expectedRF, rf)
 			} else {
 				if assert.Error(err) {
-					assert.Contains(test.expectedError, err.Error())
+					assert.Contains(err.Error(), test.expectedError)
 				}
 			}
 		})

--- a/api/redisfailover/v1/validate_test.go
+++ b/api/redisfailover/v1/validate_test.go
@@ -11,7 +11,7 @@ func TestValidate(t *testing.T) {
 	tests := []struct {
 		name                   string
 		rfName                 string
-		rfDatabaseEngine       DatabaseEngine
+		rfEngine               DatabaseEngine
 		rfBootstrapNode        *BootstrapSettings
 		rfRedisCustomConfig    []string
 		rfSentinelCustomConfig []string
@@ -28,15 +28,15 @@ func TestValidate(t *testing.T) {
 			expectedError: "name length can't be higher than 48",
 		},
 		{
-			name:             "errors on invalid databaseEngine",
+			name:             "errors on invalid engine",
 			rfName:           "test",
-			rfDatabaseEngine: DatabaseEngine("Other"),
-			expectedError:    "invalid databaseEngine",
+			rfEngine:         DatabaseEngine("Other"),
+			expectedError:    "invalid engine",
 		},
 		{
 			name:             "Valkey engine uses default Valkey image",
 			rfName:           "test",
-			rfDatabaseEngine: DatabaseEngineValkey,
+			rfEngine:         ValkeyEngine,
 		},
 		{
 			name:                   "SentinelCustomConfig provided",
@@ -83,7 +83,7 @@ func TestValidate(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			assert := assert.New(t)
 			rf := generateRedisFailover(test.rfName, test.rfBootstrapNode)
-			rf.Spec.DatabaseEngine = test.rfDatabaseEngine
+			rf.Spec.Engine = test.rfEngine
 			rf.Spec.Redis.CustomConfig = test.rfRedisCustomConfig
 			rf.Spec.Sentinel.CustomConfig = test.rfSentinelCustomConfig
 
@@ -93,7 +93,7 @@ func TestValidate(t *testing.T) {
 				assert.NoError(err)
 
 				defaultImg := defaultImage
-				if test.rfDatabaseEngine == DatabaseEngineValkey {
+				if test.rfEngine == ValkeyEngine {
 					defaultImg = defaultValkeyImage
 				}
 
@@ -119,7 +119,7 @@ func TestValidate(t *testing.T) {
 						Namespace: "namespace",
 					},
 					Spec: RedisFailoverSpec{
-						DatabaseEngine: test.rfDatabaseEngine,
+						Engine: test.rfEngine,
 						Redis: RedisSettings{
 							Image:                    defaultImg,
 							Replicas:                 defaultRedisNumber,

--- a/charts/redisoperator/crds/databases.spotahome.com_redisfailovers.yaml
+++ b/charts/redisoperator/crds/databases.spotahome.com_redisfailovers.yaml
@@ -51,6 +51,13 @@ spec:
           spec:
             description: RedisFailoverSpec represents a Redis failover spec
             properties:
+              databaseEngine:
+                description: DatabaseEngine selects Redis or Valkey. Omitted or empty
+                  means Redis (historical behavior).
+                enum:
+                - Redis
+                - Valkey
+                type: string
               auth:
                 description: AuthSettings contains settings about auth
                 properties:

--- a/charts/redisoperator/crds/databases.spotahome.com_redisfailovers.yaml
+++ b/charts/redisoperator/crds/databases.spotahome.com_redisfailovers.yaml
@@ -51,8 +51,8 @@ spec:
           spec:
             description: RedisFailoverSpec represents a Redis failover spec
             properties:
-              databaseEngine:
-                description: DatabaseEngine selects Redis or Valkey. Omitted or empty
+              engine:
+                description: Engine selects Redis or Valkey. Omitted or empty
                   means Redis (historical behavior).
                 enum:
                 - Redis

--- a/example/redisfailover/minimum-valkey.yaml
+++ b/example/redisfailover/minimum-valkey.yaml
@@ -1,0 +1,6 @@
+apiVersion: databases.spotahome.com/v1
+kind: RedisFailover
+metadata:
+  name: redisfailover-valkey
+spec:
+  databaseEngine: Valkey

--- a/manifests/databases.spotahome.com_redisfailovers.yaml
+++ b/manifests/databases.spotahome.com_redisfailovers.yaml
@@ -54,8 +54,8 @@ spec:
           spec:
             description: RedisFailoverSpec represents a Redis failover spec
             properties:
-              databaseEngine:
-                description: DatabaseEngine selects Redis or Valkey. Omitted or empty
+              engine:
+                description: Engine selects Redis or Valkey. Omitted or empty
                   means Redis (historical behavior).
                 enum:
                 - Redis

--- a/manifests/databases.spotahome.com_redisfailovers.yaml
+++ b/manifests/databases.spotahome.com_redisfailovers.yaml
@@ -54,6 +54,13 @@ spec:
           spec:
             description: RedisFailoverSpec represents a Redis failover spec
             properties:
+              databaseEngine:
+                description: DatabaseEngine selects Redis or Valkey. Omitted or empty
+                  means Redis (historical behavior).
+                enum:
+                - Redis
+                - Valkey
+                type: string
               auth:
                 description: AuthSettings contains settings about auth
                 properties:

--- a/manifests/kustomize/base/databases.spotahome.com_redisfailovers.yaml
+++ b/manifests/kustomize/base/databases.spotahome.com_redisfailovers.yaml
@@ -54,8 +54,8 @@ spec:
           spec:
             description: RedisFailoverSpec represents a Redis failover spec
             properties:
-              databaseEngine:
-                description: DatabaseEngine selects Redis or Valkey. Omitted or empty
+              engine:
+                description: Engine selects Redis or Valkey. Omitted or empty
                   means Redis (historical behavior).
                 enum:
                 - Redis

--- a/manifests/kustomize/base/databases.spotahome.com_redisfailovers.yaml
+++ b/manifests/kustomize/base/databases.spotahome.com_redisfailovers.yaml
@@ -54,6 +54,13 @@ spec:
           spec:
             description: RedisFailoverSpec represents a Redis failover spec
             properties:
+              databaseEngine:
+                description: DatabaseEngine selects Redis or Valkey. Omitted or empty
+                  means Redis (historical behavior).
+                enum:
+                - Redis
+                - Valkey
+                type: string
               auth:
                 description: AuthSettings contains settings about auth
                 properties:

--- a/operator/redisfailover/handler.go
+++ b/operator/redisfailover/handler.go
@@ -72,6 +72,10 @@ func (r *RedisFailoverHandler) Handle(_ context.Context, obj runtime.Object) err
 		return err
 	}
 
+	for _, hint := range redisfailoverv1.DatabaseEngineImageMismatchHints(rf) {
+		r.logger.Warnf("RedisFailover %s/%s databaseEngine/image hint (heuristic, non-blocking): %s", rf.Namespace, rf.Name, hint)
+	}
+
 	// Create owner refs so the objects manager by this handler have ownership to the
 	// received RF.
 	oRefs := r.createOwnerReferences(rf)

--- a/operator/redisfailover/handler.go
+++ b/operator/redisfailover/handler.go
@@ -73,7 +73,7 @@ func (r *RedisFailoverHandler) Handle(_ context.Context, obj runtime.Object) err
 	}
 
 	for _, hint := range redisfailoverv1.DatabaseEngineImageMismatchHints(rf) {
-		r.logger.Warnf("RedisFailover %s/%s databaseEngine/image hint (heuristic, non-blocking): %s", rf.Namespace, rf.Name, hint)
+		r.logger.Warnf("RedisFailover %s/%s engine/image hint (heuristic, non-blocking): %s", rf.Namespace, rf.Name, hint)
 	}
 
 	// Create owner refs so the objects manager by this handler have ownership to the

--- a/operator/redisfailover/service/engine.go
+++ b/operator/redisfailover/service/engine.go
@@ -26,8 +26,8 @@ func (valkeyEngine) CLIAuthEnvName() string { return "VALKEYCLI_AUTH" }
 
 // EngineFor returns the engine implementation for pod generation. Empty or Redis uses Redis binaries; Valkey uses Valkey binaries.
 func EngineFor(rf *redisfailoverv1.RedisFailover) DatabaseEngineProvider {
-	switch rf.Spec.DatabaseEngine {
-	case redisfailoverv1.DatabaseEngineValkey:
+	switch rf.Spec.Engine {
+	case redisfailoverv1.ValkeyEngine:
 		return valkeyEngine{}
 	default:
 		return redisEngine{}

--- a/operator/redisfailover/service/engine.go
+++ b/operator/redisfailover/service/engine.go
@@ -1,0 +1,35 @@
+package service
+
+import (
+	redisfailoverv1 "github.com/freshworks/redis-operator/api/redisfailover/v1"
+)
+
+// DatabaseEngineProvider resolves Redis vs Valkey container binaries and CLI auth for shell snippets.
+type DatabaseEngineProvider interface {
+	ServerBinary() string
+	CLIBinary() string
+	// CLIAuthEnvName is exported before invoking the CLI when REDIS_PASSWORD is set (e.g. REDISCLI_AUTH, VALKEYCLI_AUTH).
+	CLIAuthEnvName() string
+}
+
+type redisEngine struct{}
+
+func (redisEngine) ServerBinary() string    { return "redis-server" }
+func (redisEngine) CLIBinary() string         { return "redis-cli" }
+func (redisEngine) CLIAuthEnvName() string   { return "REDISCLI_AUTH" }
+
+type valkeyEngine struct{}
+
+func (valkeyEngine) ServerBinary() string    { return "valkey-server" }
+func (valkeyEngine) CLIBinary() string       { return "valkey-cli" }
+func (valkeyEngine) CLIAuthEnvName() string { return "VALKEYCLI_AUTH" }
+
+// EngineFor returns the engine implementation for pod generation. Empty or Redis uses Redis binaries; Valkey uses Valkey binaries.
+func EngineFor(rf *redisfailoverv1.RedisFailover) DatabaseEngineProvider {
+	switch rf.Spec.DatabaseEngine {
+	case redisfailoverv1.DatabaseEngineValkey:
+		return valkeyEngine{}
+	default:
+		return redisEngine{}
+	}
+}

--- a/operator/redisfailover/service/engine_test.go
+++ b/operator/redisfailover/service/engine_test.go
@@ -1,0 +1,67 @@
+package service
+
+import (
+	"testing"
+
+	redisfailoverv1 "github.com/freshworks/redis-operator/api/redisfailover/v1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestEngineFor(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		engine redisfailoverv1.DatabaseEngine
+		server string
+		cli    string
+		auth   string
+	}{
+		{"omitted is redis", "", "redis-server", "redis-cli", "REDISCLI_AUTH"},
+		{"redis", redisfailoverv1.DatabaseEngineRedis, "redis-server", "redis-cli", "REDISCLI_AUTH"},
+		{"valkey", redisfailoverv1.DatabaseEngineValkey, "valkey-server", "valkey-cli", "VALKEYCLI_AUTH"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rf := &redisfailoverv1.RedisFailover{
+				ObjectMeta: metav1.ObjectMeta{Name: "x"},
+				Spec: redisfailoverv1.RedisFailoverSpec{
+					DatabaseEngine: tc.engine,
+				},
+			}
+			eng := EngineFor(rf)
+			assert.Equal(t, tc.server, eng.ServerBinary())
+			assert.Equal(t, tc.cli, eng.CLIBinary())
+			assert.Equal(t, tc.auth, eng.CLIAuthEnvName())
+		})
+	}
+}
+
+func TestGetRedisCommandUsesEngine(t *testing.T) {
+	t.Parallel()
+	rf := &redisfailoverv1.RedisFailover{
+		ObjectMeta: metav1.ObjectMeta{Name: "x"},
+		Spec: redisfailoverv1.RedisFailoverSpec{
+			DatabaseEngine: redisfailoverv1.DatabaseEngineValkey,
+		},
+	}
+	cmd := getRedisCommand(rf, EngineFor(rf))
+	assert.Equal(t, []string{"valkey-server", "/redis/redis.conf"}, cmd)
+
+	rf.Spec.DatabaseEngine = redisfailoverv1.DatabaseEngineRedis
+	cmd = getRedisCommand(rf, EngineFor(rf))
+	assert.Equal(t, []string{"redis-server", "/redis/redis.conf"}, cmd)
+}
+
+func TestGetSentinelCommandUsesEngine(t *testing.T) {
+	t.Parallel()
+	rf := &redisfailoverv1.RedisFailover{
+		ObjectMeta: metav1.ObjectMeta{Name: "x"},
+		Spec: redisfailoverv1.RedisFailoverSpec{
+			DatabaseEngine: redisfailoverv1.DatabaseEngineValkey,
+		},
+	}
+	cmd := getSentinelCommand(rf, EngineFor(rf))
+	assert.Equal(t, []string{"valkey-server", "/redis/sentinel.conf", "--sentinel"}, cmd)
+}

--- a/operator/redisfailover/service/engine_test.go
+++ b/operator/redisfailover/service/engine_test.go
@@ -18,8 +18,8 @@ func TestEngineFor(t *testing.T) {
 		auth   string
 	}{
 		{"omitted is redis", "", "redis-server", "redis-cli", "REDISCLI_AUTH"},
-		{"redis", redisfailoverv1.DatabaseEngineRedis, "redis-server", "redis-cli", "REDISCLI_AUTH"},
-		{"valkey", redisfailoverv1.DatabaseEngineValkey, "valkey-server", "valkey-cli", "VALKEYCLI_AUTH"},
+		{"redis", redisfailoverv1.RedisEngine, "redis-server", "redis-cli", "REDISCLI_AUTH"},
+		{"valkey", redisfailoverv1.ValkeyEngine, "valkey-server", "valkey-cli", "VALKEYCLI_AUTH"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -27,7 +27,7 @@ func TestEngineFor(t *testing.T) {
 			rf := &redisfailoverv1.RedisFailover{
 				ObjectMeta: metav1.ObjectMeta{Name: "x"},
 				Spec: redisfailoverv1.RedisFailoverSpec{
-					DatabaseEngine: tc.engine,
+					Engine: tc.engine,
 				},
 			}
 			eng := EngineFor(rf)
@@ -43,13 +43,13 @@ func TestGetRedisCommandUsesEngine(t *testing.T) {
 	rf := &redisfailoverv1.RedisFailover{
 		ObjectMeta: metav1.ObjectMeta{Name: "x"},
 		Spec: redisfailoverv1.RedisFailoverSpec{
-			DatabaseEngine: redisfailoverv1.DatabaseEngineValkey,
+			Engine: redisfailoverv1.ValkeyEngine,
 		},
 	}
 	cmd := getRedisCommand(rf, EngineFor(rf))
 	assert.Equal(t, []string{"valkey-server", "/redis/redis.conf"}, cmd)
 
-	rf.Spec.DatabaseEngine = redisfailoverv1.DatabaseEngineRedis
+	rf.Spec.Engine = redisfailoverv1.RedisEngine
 	cmd = getRedisCommand(rf, EngineFor(rf))
 	assert.Equal(t, []string{"redis-server", "/redis/redis.conf"}, cmd)
 }
@@ -59,7 +59,7 @@ func TestGetSentinelCommandUsesEngine(t *testing.T) {
 	rf := &redisfailoverv1.RedisFailover{
 		ObjectMeta: metav1.ObjectMeta{Name: "x"},
 		Spec: redisfailoverv1.RedisFailoverSpec{
-			DatabaseEngine: redisfailoverv1.DatabaseEngineValkey,
+			Engine: redisfailoverv1.ValkeyEngine,
 		},
 	}
 	cmd := getSentinelCommand(rf, EngineFor(rf))

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -257,17 +257,20 @@ func generateRedisShutdownConfigMap(rf *redisfailoverv1.RedisFailover, labels ma
 	rfName := strings.ReplaceAll(strings.ToUpper(rf.Name), "-", "_")
 
 	labels = util.MergeLabels(labels, generateSelectorLabels(redisRoleName, rf.Name))
-	shutdownContent := fmt.Sprintf(`master=$(redis-cli -h ${RFS_%[1]v_SERVICE_HOST} -p ${RFS_%[1]v_SERVICE_PORT_SENTINEL} --csv SENTINEL get-master-addr-by-name %[3]v | tr ',' ' ' | tr -d '\"' |cut -d' ' -f1)
+	eng := EngineFor(rf)
+	cli := eng.CLIBinary()
+	authEnv := eng.CLIAuthEnvName()
+	shutdownContent := fmt.Sprintf(`master=$(%[4]s -h ${RFS_%[1]v_SERVICE_HOST} -p ${RFS_%[1]v_SERVICE_PORT_SENTINEL} --csv SENTINEL get-master-addr-by-name %[3]v | tr ',' ' ' | tr -d '\"' |cut -d' ' -f1)
 if [ "$master" = "$(hostname -i)" ]; then
-redis-cli -h ${RFS_%[1]v_SERVICE_HOST} -p ${RFS_%[1]v_SERVICE_PORT_SENTINEL} SENTINEL failover %[3]v
+%[4]s -h ${RFS_%[1]v_SERVICE_HOST} -p ${RFS_%[1]v_SERVICE_PORT_SENTINEL} SENTINEL failover %[3]v
 sleep 31
 fi
-cmd="redis-cli -p %[2]v"
+cmd="%[4]s -p %[2]v"
 if [ ! -z "${REDIS_PASSWORD}" ]; then
-	export REDISCLI_AUTH=${REDIS_PASSWORD}
+	export %[5]s=${REDIS_PASSWORD}
 fi
 save_command="${cmd} save"
-eval $save_command`, rfName, port, rf.MasterName())
+eval $save_command`, rfName, port, rf.MasterName(), cli, authEnv)
 
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -288,15 +291,18 @@ func generateRedisReadinessConfigMap(rf *redisfailoverv1.RedisFailover, labels m
 	namespace := rf.Namespace
 
 	labels = util.MergeLabels(labels, generateSelectorLabels(redisRoleName, rf.Name))
+	eng := EngineFor(rf)
+	cli := eng.CLIBinary()
+	authEnv := eng.CLIAuthEnvName()
 	readinessContent := fmt.Sprintf(`ROLE="role"
 ROLE_MASTER="role:master"
 ROLE_SLAVE="role:slave"
 IN_SYNC="master_sync_in_progress:1"
 NO_MASTER="master_host:127.0.0.1"
 
-cmd="redis-cli -p %[1]v"
+cmd="%[2]s -p %[1]v"
 if [ ! -z "${REDIS_PASSWORD}" ]; then
-	export REDISCLI_AUTH=${REDIS_PASSWORD}
+	export %[3]s=${REDIS_PASSWORD}
 fi
 
 cmd="${cmd} info replication"
@@ -327,7 +333,7 @@ case $role in
 		*)
 				echo "unexpected"
 				exit 1
-esac`, port)
+esac`, port, cli, authEnv)
 
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -346,7 +352,8 @@ func generateRedisStatefulSet(rf *redisfailoverv1.RedisFailover, labels map[stri
 	name := GetRedisName(rf)
 	namespace := rf.Namespace
 
-	redisCommand := getRedisCommand(rf)
+	eng := EngineFor(rf)
+	redisCommand := getRedisCommand(rf, eng)
 	selectorLabels := generateSelectorLabels(redisRoleName, rf.Name)
 	labels = util.MergeLabels(labels, selectorLabels)
 	labels = util.MergeLabels(labels, generateRedisDefaultRoleLabel())
@@ -458,7 +465,7 @@ func generateRedisStatefulSet(rf *redisfailoverv1.RedisFailover, labels map[stri
 					Command: []string{
 						"sh",
 						"-c",
-						fmt.Sprintf("redis-cli -h $(hostname) -p %[1]v --user pinger --pass pingpass --no-auth-warning ping | grep PONG", rf.Spec.Redis.Port),
+						fmt.Sprintf("%s -h $(hostname) -p %v --user pinger --pass pingpass --no-auth-warning ping | grep PONG", eng.CLIBinary(), rf.Spec.Redis.Port),
 					},
 				},
 			},
@@ -521,7 +528,8 @@ func generateSentinelDeployment(rf *redisfailoverv1.RedisFailover, labels map[st
 	configMapName := GetSentinelName(rf)
 	namespace := rf.Namespace
 
-	sentinelCommand := getSentinelCommand(rf)
+	eng := EngineFor(rf)
+	sentinelCommand := getSentinelCommand(rf, eng)
 	selectorLabels := generateSelectorLabels(sentinelRoleName, rf.Name)
 	labels = util.MergeLabels(labels, selectorLabels)
 
@@ -624,7 +632,7 @@ func generateSentinelDeployment(rf *redisfailoverv1.RedisFailover, labels map[st
 					Command: []string{
 						"sh",
 						"-c",
-						"redis-cli -h $(hostname) -p 26379 ping",
+						fmt.Sprintf("%s -h $(hostname) -p 26379 ping", eng.CLIBinary()),
 					},
 				},
 			},
@@ -634,7 +642,7 @@ func generateSentinelDeployment(rf *redisfailoverv1.RedisFailover, labels map[st
 	if rf.Spec.Sentinel.CustomReadinessProbe != nil {
 		sd.Spec.Template.Spec.Containers[0].ReadinessProbe = rf.Spec.Sentinel.CustomReadinessProbe
 	} else {
-		probeCommand := fmt.Sprintf("redis-cli -h $(hostname) -p 26379 sentinel get-master-addr-by-name %s | head -n 1 | grep -vq '127.0.0.1'", rf.MasterName())
+		probeCommand := fmt.Sprintf("%s -h $(hostname) -p 26379 sentinel get-master-addr-by-name %s | head -n 1 | grep -vq '127.0.0.1'", eng.CLIBinary(), rf.MasterName())
 		sd.Spec.Template.Spec.Containers[0].ReadinessProbe = &corev1.Probe{
 			InitialDelaySeconds: graceTime,
 			TimeoutSeconds:      5,
@@ -1068,22 +1076,22 @@ func getRedisDataVolumeName(rf *redisfailoverv1.RedisFailover) string {
 	}
 }
 
-func getRedisCommand(rf *redisfailoverv1.RedisFailover) []string {
+func getRedisCommand(rf *redisfailoverv1.RedisFailover, eng DatabaseEngineProvider) []string {
 	if len(rf.Spec.Redis.Command) > 0 {
 		return rf.Spec.Redis.Command
 	}
 	return []string{
-		"redis-server",
+		eng.ServerBinary(),
 		fmt.Sprintf("/redis/%s", redisConfigFileName),
 	}
 }
 
-func getSentinelCommand(rf *redisfailoverv1.RedisFailover) []string {
+func getSentinelCommand(rf *redisfailoverv1.RedisFailover, eng DatabaseEngineProvider) []string {
 	if len(rf.Spec.Sentinel.Command) > 0 {
 		return rf.Spec.Sentinel.Command
 	}
 	return []string{
-		"redis-server",
+		eng.ServerBinary(),
 		fmt.Sprintf("/redis/%s", sentinelConfigFileName),
 		"--sentinel",
 	}

--- a/test/integration/redisfailover/creation_test.go
+++ b/test/integration/redisfailover/creation_test.go
@@ -357,25 +357,35 @@ func (c *clients) testCRCreation(t *testing.T, currentNamespace string, args ...
 	assert.Equal(toCreate.Spec, gotRF.Spec)
 }
 
-func (c *clients) testRedisStatefulSet(t *testing.T, currentNamespace string) {
+func redisFailoverName(rfName ...string) string {
+	if len(rfName) > 0 && rfName[0] != "" {
+		return rfName[0]
+	}
+	return name
+}
+
+func (c *clients) testRedisStatefulSet(t *testing.T, currentNamespace string, rfName ...string) {
 	assert := assert.New(t)
-	redisSS, err := c.k8sClient.AppsV1().StatefulSets(currentNamespace).Get(context.Background(), fmt.Sprintf("rfr-%s", name), metav1.GetOptions{})
+	rn := redisFailoverName(rfName...)
+	redisSS, err := c.k8sClient.AppsV1().StatefulSets(currentNamespace).Get(context.Background(), fmt.Sprintf("rfr-%s", rn), metav1.GetOptions{})
 	assert.NoError(err)
 	assert.Equal(redisSize, int32(redisSS.Status.Replicas))
 }
 
-func (c *clients) testSentinelDeployment(t *testing.T, currentNamespace string) {
+func (c *clients) testSentinelDeployment(t *testing.T, currentNamespace string, rfName ...string) {
 	assert := assert.New(t)
-	sentinelD, err := c.k8sClient.AppsV1().Deployments(currentNamespace).Get(context.Background(), fmt.Sprintf("rfs-%s", name), metav1.GetOptions{})
+	rn := redisFailoverName(rfName...)
+	sentinelD, err := c.k8sClient.AppsV1().Deployments(currentNamespace).Get(context.Background(), fmt.Sprintf("rfs-%s", rn), metav1.GetOptions{})
 	assert.NoError(err)
 	assert.Equal(3, int(sentinelD.Status.Replicas))
 }
 
-func (c *clients) testRedisMaster(t *testing.T, currentNamespace string) {
+func (c *clients) testRedisMaster(t *testing.T, currentNamespace string, rfName ...string) {
 	assert := assert.New(t)
+	rn := redisFailoverName(rfName...)
 	masters := []string{}
 
-	redisSS, err := c.k8sClient.AppsV1().StatefulSets(currentNamespace).Get(context.Background(), fmt.Sprintf("rfr-%s", name), metav1.GetOptions{})
+	redisSS, err := c.k8sClient.AppsV1().StatefulSets(currentNamespace).Get(context.Background(), fmt.Sprintf("rfr-%s", rn), metav1.GetOptions{})
 	assert.NoError(err)
 
 	listOptions := metav1.ListOptions{
@@ -396,21 +406,17 @@ func (c *clients) testRedisMaster(t *testing.T, currentNamespace string) {
 	assert.Equal(1, len(masters), "only one master expected")
 }
 
-func (c *clients) testSentinelMonitoring(t *testing.T, currentNamespace string, args ...bool) {
-	disableMyMaster := false
-	if len(args) > 0 {
-		disableMyMaster = args[0]
-	}
-
+func (c *clients) testSentinelMonitoring(t *testing.T, currentNamespace string, disableMyMaster bool, rfName ...string) {
+	rn := redisFailoverName(rfName...)
 	masterName := "mymaster"
 	if disableMyMaster {
-		masterName = name
+		masterName = rn
 	}
 
 	assert := assert.New(t)
 	masters := []string{}
 
-	sentinelD, err := c.k8sClient.AppsV1().Deployments(currentNamespace).Get(context.Background(), fmt.Sprintf("rfs-%s", name), metav1.GetOptions{})
+	sentinelD, err := c.k8sClient.AppsV1().Deployments(currentNamespace).Get(context.Background(), fmt.Sprintf("rfs-%s", rn), metav1.GetOptions{})
 	assert.NoError(err)
 
 	listOptions := metav1.ListOptions{
@@ -434,15 +440,16 @@ func (c *clients) testSentinelMonitoring(t *testing.T, currentNamespace string, 
 	assert.True(isMaster, "Sentinel should monitor the Redis master")
 }
 
-func (c *clients) testAuth(t *testing.T, currentNamespace string) {
+func (c *clients) testAuth(t *testing.T, currentNamespace string, rfName ...string) {
 	assert := assert.New(t)
+	rn := redisFailoverName(rfName...)
 
-	redisCfg, err := c.k8sClient.CoreV1().ConfigMaps(currentNamespace).Get(context.Background(), fmt.Sprintf("rfr-%s", name), metav1.GetOptions{})
+	redisCfg, err := c.k8sClient.CoreV1().ConfigMaps(currentNamespace).Get(context.Background(), fmt.Sprintf("rfr-%s", rn), metav1.GetOptions{})
 	assert.NoError(err)
 	assert.Contains(redisCfg.Data["redis.conf"], "requirepass "+testPass)
 	assert.Contains(redisCfg.Data["redis.conf"], "masterauth "+testPass)
 
-	redisSS, err := c.k8sClient.AppsV1().StatefulSets(currentNamespace).Get(context.Background(), fmt.Sprintf("rfr-%s", name), metav1.GetOptions{})
+	redisSS, err := c.k8sClient.AppsV1().StatefulSets(currentNamespace).Get(context.Background(), fmt.Sprintf("rfr-%s", rn), metav1.GetOptions{})
 	assert.NoError(err)
 
 	assert.Len(redisSS.Spec.Template.Spec.Containers, 2)
@@ -457,10 +464,11 @@ func (c *clients) testAuth(t *testing.T, currentNamespace string) {
 	assert.Equal(redisSS.Spec.Template.Spec.Containers[1].Env[4].ValueFrom.SecretKeyRef.LocalObjectReference.Name, authSecretPath)
 }
 
-func (c *clients) testCustomConfig(t *testing.T, currentNamespace string) {
+func (c *clients) testCustomConfig(t *testing.T, currentNamespace string, rfName ...string) {
 	assert := assert.New(t)
+	rn := redisFailoverName(rfName...)
 
-	redisSS, err := c.k8sClient.AppsV1().StatefulSets(currentNamespace).Get(context.Background(), fmt.Sprintf("rfr-%s", name), metav1.GetOptions{})
+	redisSS, err := c.k8sClient.AppsV1().StatefulSets(currentNamespace).Get(context.Background(), fmt.Sprintf("rfr-%s", rn), metav1.GetOptions{})
 	assert.NoError(err)
 
 	listOptions := metav1.ListOptions{

--- a/test/integration/redisfailover/database_engine_test.go
+++ b/test/integration/redisfailover/database_engine_test.go
@@ -1,0 +1,194 @@
+//go:build integration
+// +build integration
+
+package redisfailover_test
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/homedir"
+
+	redisfailoverv1 "github.com/freshworks/redis-operator/api/redisfailover/v1"
+	"github.com/freshworks/redis-operator/cmd/utils"
+	"github.com/freshworks/redis-operator/log"
+	"github.com/freshworks/redis-operator/metrics"
+	"github.com/freshworks/redis-operator/operator/redisfailover"
+	"github.com/freshworks/redis-operator/service/k8s"
+	"github.com/freshworks/redis-operator/service/redis"
+)
+
+const (
+	valkeyIntegrationNamespace = "testns-valkey"
+	valkeyIntegrationRFName    = "testing-valkey"
+)
+
+// TestRedisFailoverValkeyDatabaseEngine exercises spec.databaseEngine=Valkey end-to-end against a real cluster:
+// generated workloads use valkey-server / valkey-cli, auth and replication behave like the default Redis test.
+func TestRedisFailoverValkeyDatabaseEngine(t *testing.T) {
+	require := require.New(t)
+	disableMyMaster := true
+	currentNamespace := valkeyIntegrationNamespace
+	rfName := valkeyIntegrationRFName
+
+	stopC := make(chan struct{})
+	errC := make(chan error)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	flags := &utils.CMDFlags{
+		KubeConfig:  filepath.Join(homedir.HomeDir(), ".kube", "config"),
+		Development: true,
+	}
+
+	k8sClient, customClient, aeClientset, err := utils.CreateKubernetesClients(flags)
+	require.NoError(err)
+
+	redisClient := redis.New(metrics.Dummy)
+
+	clients := clients{
+		k8sClient:   k8sClient,
+		rfClient:    customClient,
+		aeClient:    aeClientset,
+		redisClient: redisClient,
+	}
+
+	k8sservice := k8s.New(k8sClient, customClient, aeClientset, log.Dummy, metrics.Dummy)
+
+	prepErr := clients.prepareNS(currentNamespace)
+	require.NoError(prepErr)
+
+	time.Sleep(15 * time.Second)
+
+	redisfailoverOperator, err := redisfailover.New(redisfailover.Config{OperatorGroupID: integrationTestGroupID}, k8sservice, k8sClient, currentNamespace, redisClient, metrics.Dummy, log.Dummy)
+	require.NoError(err)
+
+	go func() {
+		errC <- redisfailoverOperator.Run(ctx)
+	}()
+
+	defer cancel()
+	defer clients.cleanup(stopC, currentNamespace)
+
+	time.Sleep(15 * time.Second)
+
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      authSecretPath,
+			Namespace: currentNamespace,
+		},
+		Data: map[string][]byte{
+			"password": []byte(testPass),
+		},
+	}
+	_, err = k8sClient.CoreV1().Secrets(currentNamespace).Create(context.Background(), secret, metav1.CreateOptions{})
+	require.NoError(err)
+
+	ok := t.Run("Check Custom Resource Creation (Valkey)", func(t *testing.T) {
+		clients.testValkeyCRCreation(t, currentNamespace, rfName, disableMyMaster)
+	})
+	require.True(ok, "the Valkey custom resource has to be created to continue")
+
+	time.Sleep(3 * time.Minute)
+
+	t.Run("Valkey StatefulSet and Sentinel use valkey-server and valkey-cli", func(t *testing.T) {
+		clients.testValkeyWorkloadBinaries(t, currentNamespace, rfName)
+	})
+
+	t.Run("Check that auth is set in sentinel and redis configs (Valkey)", func(t *testing.T) {
+		clients.testAuth(t, currentNamespace, rfName)
+	})
+
+	t.Run("Check that custom config behaves as expected (Valkey)", func(t *testing.T) {
+		clients.testCustomConfig(t, currentNamespace, rfName)
+	})
+
+	t.Run("Check Redis StatefulSet existing and size (Valkey)", func(t *testing.T) {
+		clients.testRedisStatefulSet(t, currentNamespace, rfName)
+	})
+
+	t.Run("Check Sentinel Deployment existing and size (Valkey)", func(t *testing.T) {
+		clients.testSentinelDeployment(t, currentNamespace, rfName)
+	})
+
+	t.Run("Check Only One Redis Master (Valkey)", func(t *testing.T) {
+		clients.testRedisMaster(t, currentNamespace, rfName)
+	})
+
+	t.Run("Check Sentinels monitoring Redis Master (Valkey)", func(t *testing.T) {
+		clients.testSentinelMonitoring(t, currentNamespace, disableMyMaster, rfName)
+	})
+}
+
+func (c *clients) testValkeyCRCreation(t *testing.T, currentNamespace, rfName string, disableMyMaster bool) {
+	assert := assert.New(t)
+	toCreate := &redisfailoverv1.RedisFailover{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      rfName,
+			Namespace: currentNamespace,
+			Labels:    map[string]string{rfOperatorGroupLabelKey: integrationTestGroupID},
+		},
+		Spec: redisfailoverv1.RedisFailoverSpec{
+			DatabaseEngine: redisfailoverv1.DatabaseEngineValkey,
+			Redis: redisfailoverv1.RedisSettings{
+				Replicas: redisSize,
+				Exporter: redisfailoverv1.Exporter{
+					Enabled: true,
+				},
+				CustomConfig: []string{`save ""`},
+			},
+			Sentinel: redisfailoverv1.SentinelSettings{
+				Replicas:        sentinelSize,
+				DisableMyMaster: disableMyMaster,
+			},
+			Auth: redisfailoverv1.AuthSettings{
+				SecretPath: authSecretPath,
+			},
+		},
+	}
+
+	_, err := c.rfClient.DatabasesV1().RedisFailovers(currentNamespace).Create(context.Background(), toCreate, metav1.CreateOptions{})
+	assert.NoError(err)
+	gotRF, err := c.rfClient.DatabasesV1().RedisFailovers(currentNamespace).Get(context.Background(), rfName, metav1.GetOptions{})
+	assert.NoError(err)
+	assert.Equal(toCreate.Spec, gotRF.Spec)
+}
+
+func (c *clients) testValkeyWorkloadBinaries(t *testing.T, currentNamespace, rfName string) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	redisSS, err := c.k8sClient.AppsV1().StatefulSets(currentNamespace).Get(context.Background(), fmt.Sprintf("rfr-%s", rfName), metav1.GetOptions{})
+	require.NoError(err)
+	require.NotNil(redisSS.Spec.Template.Spec.Containers[0].Command)
+	assert.Equal("valkey-server", redisSS.Spec.Template.Spec.Containers[0].Command[0])
+	require.NotNil(redisSS.Spec.Template.Spec.Containers[0].LivenessProbe)
+	require.NotNil(redisSS.Spec.Template.Spec.Containers[0].LivenessProbe.Exec)
+	assert.Len(redisSS.Spec.Template.Spec.Containers[0].LivenessProbe.Exec.Command, 3)
+	assert.Contains(redisSS.Spec.Template.Spec.Containers[0].LivenessProbe.Exec.Command[2], "valkey-cli")
+
+	sentinelD, err := c.k8sClient.AppsV1().Deployments(currentNamespace).Get(context.Background(), fmt.Sprintf("rfs-%s", rfName), metav1.GetOptions{})
+	require.NoError(err)
+	require.NotNil(sentinelD.Spec.Template.Spec.Containers[0].Command)
+	assert.Equal("valkey-server", sentinelD.Spec.Template.Spec.Containers[0].Command[0])
+	require.NotNil(sentinelD.Spec.Template.Spec.Containers[0].LivenessProbe.Exec)
+	assert.Contains(sentinelD.Spec.Template.Spec.Containers[0].LivenessProbe.Exec.Command[2], "valkey-cli")
+	require.NotNil(sentinelD.Spec.Template.Spec.Containers[0].ReadinessProbe.Exec)
+	assert.Contains(sentinelD.Spec.Template.Spec.Containers[0].ReadinessProbe.Exec.Command[2], "valkey-cli")
+
+	shutdownCM, err := c.k8sClient.CoreV1().ConfigMaps(currentNamespace).Get(context.Background(), fmt.Sprintf("rfr-s-%s", rfName), metav1.GetOptions{})
+	require.NoError(err)
+	assert.Contains(shutdownCM.Data["shutdown.sh"], "valkey-cli")
+	assert.Contains(shutdownCM.Data["shutdown.sh"], "VALKEYCLI_AUTH")
+
+	readinessCM, err := c.k8sClient.CoreV1().ConfigMaps(currentNamespace).Get(context.Background(), fmt.Sprintf("rfr-readiness-%s", rfName), metav1.GetOptions{})
+	require.NoError(err)
+	assert.Contains(readinessCM.Data["ready.sh"], "valkey-cli")
+	assert.Contains(readinessCM.Data["ready.sh"], "VALKEYCLI_AUTH")
+}

--- a/test/integration/redisfailover/database_engine_test.go
+++ b/test/integration/redisfailover/database_engine_test.go
@@ -30,7 +30,7 @@ const (
 	valkeyIntegrationRFName    = "testing-valkey"
 )
 
-// TestRedisFailoverValkeyDatabaseEngine exercises spec.databaseEngine=Valkey end-to-end against a real cluster:
+// TestRedisFailoverValkeyDatabaseEngine exercises spec.engine=Valkey end-to-end against a real cluster:
 // generated workloads use valkey-server / valkey-cli, auth and replication behave like the default Redis test.
 func TestRedisFailoverValkeyDatabaseEngine(t *testing.T) {
 	require := require.New(t)
@@ -135,7 +135,7 @@ func (c *clients) testValkeyCRCreation(t *testing.T, currentNamespace, rfName st
 			Labels:    map[string]string{rfOperatorGroupLabelKey: integrationTestGroupID},
 		},
 		Spec: redisfailoverv1.RedisFailoverSpec{
-			DatabaseEngine: redisfailoverv1.DatabaseEngineValkey,
+			Engine: redisfailoverv1.ValkeyEngine,
 			Redis: redisfailoverv1.RedisSettings{
 				Replicas: redisSize,
 				Exporter: redisfailoverv1.Exporter{


### PR DESCRIPTION
## Summary

Adds optional `spec.databaseEngine` (`Redis` | `Valkey`) so one `RedisFailover` API can run either stock Redis or Valkey workloads. When omitted or empty, behavior stays **Redis** (same defaults as before).

## Behavior

- **Redis (default):** `redis-server`, `redis-cli`, `REDISCLI_AUTH` in scripts; default image unchanged unless specified.
- **Valkey:** `valkey-server`, `valkey-cli`, `VALKEYCLI_AUTH` in shutdown/readiness scripts; 
- **`spec.redis.command` / `spec.sentinel.command`** still override the main process only; probes/scripts continue to use the engine’s CLI unless customized later.

## Implementation notes

- `operator/redisfailover/service/engine.go` — `DatabaseEngineProvider` (`redisEngine` / `valkeyEngine`) + `EngineFor(rf)`.
- `operator/redisfailover/service/generator.go` — commands, liveness/readiness exec probes, shutdown + readiness ConfigMaps driven by the provider.
- `api/redisfailover/v1` — `DatabaseEngine` enum, `spec.databaseEngine`, `defaultValkeyImage`, validation for enum + default images.
- `api/redisfailover/v1/engine_image_hint.go` — soft, non-blocking heuristic hints (substring checks on image names) + `Warnf` from `handler.go` after successful validate (no CRD status subresource).

## Manifests / examples

- CRD schema includes `databaseEngine` (chart CRD / kustomize base where updated).
- `example/redisfailover/minimum-valkey.yaml` — `databaseEngine: Valkey` + `redis-failover.freshworks.com/operator-group` label aligned with operator `OPERATOR_GROUP_ID`.

## Tests

- **Unit:** `operator/redisfailover/service/engine_test.go`, `engine_image_hint_test.go`.
- **Integration** (`-tags=integration`): `TestRedisFailoverValkeyDatabaseEngine` + optional `rfName` on shared helpers in `creation_test.go`.

## Makefile

- **`image-release`:** Docker Buildx multi-arch `--push` when using Docker; Podman path builds single-arch and `podman push` (documented limitation).