### PR TITLE
chart: add extraEnvVars so required OPERATOR_GROUP_ID can be set

### DIFF
--- a/charts/redisoperator/Chart.yaml
+++ b/charts/redisoperator/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: 1.3.0
 apiVersion: v1
 description: A Helm chart for the Redis Operator
 name: redis-operator
-version: 3.3.4
+version: 3.3.5
 home: https://github.com/freshworks/redis-operator
 keywords:
   - "golang"

--- a/charts/redisoperator/templates/deployment.yaml
+++ b/charts/redisoperator/templates/deployment.yaml
@@ -46,6 +46,10 @@ spec:
         - {{ quote .Values.image.cli_args }}
         {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- if .Values.extraEnvVars }}
+        env:
+          {{- toYaml .Values.extraEnvVars | nindent 10 }}
+        {{- end }}
         ports:
           - name: metrics
             containerPort: {{ .Values.container.port }}

--- a/charts/redisoperator/values.yaml
+++ b/charts/redisoperator/values.yaml
@@ -53,6 +53,13 @@ service:
 container:
   port: 9710
 
+# Extra environment variables to add to the operator container, using the
+# native Kubernetes EnvVar schema, e.g.:
+# extraEnvVars:
+#   - name: FOO
+#     value: bar
+extraEnvVars: []
+
 # Container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container).
 # See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1) for details.
 securityContext:


### PR DESCRIPTION
Fixes #68

The operator requires `OPERATOR_GROUP_ID` and fails fast without it (`cmd/redisoperator/main.go:91-93`), but the chart had no way to set it: no env/extraEnvVars field in `values.yaml`, and no `env:` block in the Deployment template at all.

Adds `extraEnvVars`, a plain list using the native Kubernetes EnvVar schema - the same convention used by charts like Bitnami's and ingress-nginx. Covers `OPERATOR_GROUP_ID` and any future env var, including `valueFrom` (e.g. `secretKeyRef`), with no extra plumbing needed. Rendered on the container only when non-empty, so existing installs are unaffected by default.

Verified with `helm template`:
```
extraEnvVars:
  - name: OPERATOR_GROUP_ID
    value: default
```
renders:
```
env:
  - name: OPERATOR_GROUP_ID
    value: default
```